### PR TITLE
Fix: Prevent the daemon from starting if the sync box is not detected

### DIFF
--- a/code/synchronization/forward-trigger-service.py
+++ b/code/synchronization/forward-trigger-service.py
@@ -25,7 +25,6 @@ from pathlib import Path
 import serial
 import asyncio
 import logging
-
 import janus
 import keyboard
 import usb.core
@@ -138,9 +137,13 @@ def check_usb_device_connected(usb_vendor_id, usb_product_id):
     Returns:
         bool: True if the device is connected, False otherwise.
     """
-    device = usb.core.find(idVendor=int(usb_vendor_id, 16), idProduct=int(usb_product_id, 16))
+    device = usb.core.find(
+        idVendor=int(usb_vendor_id, 16), idProduct=int(usb_product_id, 16)
+    )
     if device is None:
-        raise RuntimeError(f"USB device (Vendor ID: {usb_vendor_id}, Product ID: {usb_product_id}) is not connected.")
+        raise RuntimeError(
+            f"USB device (Vendor ID: {usb_vendor_id}, Product ID: {usb_product_id}) is not connected."
+        )
     return True
 
 
@@ -150,7 +153,9 @@ async def main() -> None:
     Run the signal server and forward the signals to the serial port.
     """
     # Check if the USB device is connected
-    initial_usb_connection = check_usb_device_connected("07c0", "0101") #for testing "0bc2", "2322"
+    initial_usb_connection = check_usb_device_connected(
+        "07c0", "0101"
+    )  # for testing "0bc2", "2322"
 
     # Initiate a Queue that has synchronous and asynchronous endpoints.
     signal_queue: janus.Queue[int] = janus.Queue()

--- a/code/synchronization/forward-trigger-service.py
+++ b/code/synchronization/forward-trigger-service.py
@@ -128,7 +128,7 @@ def _trigger(sync_q: janus.SyncQueue[int]) -> None:
     logging.info("Scanner trigger received")
 
 
-def check_usb_device_connected(usb_vendor_id, usb_product_id):
+def ensure_usb_device_connected(usb_vendor_id, usb_product_id):
     """
     Check if a USB device with the specified vendor and product IDs is connected.
     

--- a/code/synchronization/forward-trigger-service.py
+++ b/code/synchronization/forward-trigger-service.py
@@ -181,9 +181,7 @@ async def main() -> None:
     
     """
     # Check if the USB device is connected
-    ensure_usb_device_connected(
-        "07c0", "0101"
-    )  # for testing "0bc2", "2322"
+    ensure_usb_device_connected(*USB_MMBTS_DEVICE_ID)
 
     # Initiate a Queue that has synchronous and asynchronous endpoints.
     signal_queue: janus.Queue[int] = janus.Queue()

--- a/code/synchronization/forward-trigger-service.py
+++ b/code/synchronization/forward-trigger-service.py
@@ -162,7 +162,7 @@ async def main() -> None:
     Run the signal server and forward the signals to the serial port.
     """
     # Check if the USB device is connected
-    initial_usb_connection = check_usb_device_connected(
+    ensure_usb_device_connected(
         "07c0", "0101"
     )  # for testing "0bc2", "2322"
 

--- a/code/synchronization/forward-trigger-service.py
+++ b/code/synchronization/forward-trigger-service.py
@@ -131,11 +131,20 @@ def _trigger(sync_q: janus.SyncQueue[int]) -> None:
 def check_usb_device_connected(usb_vendor_id, usb_product_id):
     """
     Check if a USB device with the specified vendor and product IDs is connected.
-    Parameters:
-        usb_vendor_id (str): The USB vendor ID.
-        usb_product_id (str): The USB product ID.
-    Returns:
-        bool: True if the device is connected, False otherwise.
+    
+    Parameters
+    ----------
+    usb_vendor_id : :obj:`str`
+        Vendor ID of a USB device.
+    usb_product_id : :obj:`str`
+        Product ID of a USB device.
+
+    Returns
+    -------
+    connected : :obj:`bool`
+        ``True`` when the device is connected. If the device is not connected, this
+        function raises a :obj:`RuntimeError`.
+
     """
     device = usb.core.find(
         idVendor=int(usb_vendor_id, 16), idProduct=int(usb_product_id, 16)

--- a/code/synchronization/forward-trigger-service.py
+++ b/code/synchronization/forward-trigger-service.py
@@ -31,7 +31,7 @@ import usb.core
 import usb.util
 
 
-LISTEN = 8888
+LISTEN = 2023
 SERIAL_PORT = "/dev/ttyACM0"
 LOG_FILE = Path.home() / "var" / "log" / "forward-trigger-service.log"
 

--- a/docs/data-collection/pre-session.md
+++ b/docs/data-collection/pre-session.md
@@ -203,7 +203,17 @@ Instructions of operations to be performed before the participant arrival, **bef
     
 - [ ] Configure the display settings of the laptop to mirror outputs and set a resolution of 800x600 for both screens.
 - [ ] Double check that the IP address corresponding to the ethernet interface of the *{{ secrets.hosts.psychopy | default("███") }}* laptop is correct. You can either run `ifconfig -a` or use the GUI. Make sure the IP/mask is **100.1.1.2/24**, and the protocol is IP version 4. Execute `ping 100.1.1.1` to see if the ET is responding to echoes.
-- [ ] Check that the service to synchronize the triggers is on with `sudo systemctl status forward-trigger`. If not, run `sudo systemctl status forward-trigger` and recheck the status.
+- [ ] Check that the service to synchronize the triggers is up with `sudo systemctl status forward-trigger`.
+
+    !!! warning "If the service is down, manually force its start"
+    
+        - [ ] Run `sudo systemctl status forward-trigger`
+        - [ ] Recheck the status with `sudo systemctl status forward-trigger`.
+    
+    !!! important "These commands are executed with `sudo`"
+    
+        The console will prompt you for the common user password: `{{ secrets.login.password_hos68752 | default("****") }}`
+
 - [ ] Check that you can send trigger events manually:
     - [ ] Enter the "Synchronization" menu by selecting it and pushing the enter button (&#x25CF;).
     - [ ] Hit the down arrow button (&#x25BC;) until you find "Send trigger"

--- a/docs/data-collection/pre-session.md
+++ b/docs/data-collection/pre-session.md
@@ -63,8 +63,8 @@ Instructions of operations to be performed before the participant arrival, **bef
     ![mac_setup](../assets/images/mac_setup.png) 
 - [ ] Connect one end of the parallel cable on the parallel plug on the back side of the STP100D unit of the BIOPAC and the other end to the parallel port of the NEUROSPEC parallel-to USB-converter.
     ![biopac-parallel-plug](../assets/images/biopac-parallel-plug.jpg "BIOPAC back side")
-    ![neurospec](../assets/images/neurospec.jpg)
-- [ ] Connect that NEUROSPEC adapter to one of the USB port of the laptop *{{ secrets.hosts.psychopy | default("███") }}*.
+    ![neurospec](../assets/images/neurospec.jpg) ** Do not connect the NEUROSPEC parallel-to USB-converter to *{{ secrets.hosts.psychopy | default("███") }}* now. It must always be connected after the USB cable of the sync box.**
+
 
     ![neurospec_usb](../assets/images/neurospec_usb.jpg)
 
@@ -191,6 +191,8 @@ Instructions of operations to be performed before the participant arrival, **bef
     !!! warning "If the monitor does not automatically switch the source of the screen, you can use the button below to switch it." 
     
         ![switch_screen](../assets/images/screen_switch.jpg)
+      
+- [ ] Connect the NEUROSPEC adapter (pink USB cable) to one of the USB port of the laptop *{{ secrets.hosts.psychopy | default("███") }}*. **This cable must always be connected last.**
 
 - Your laptop connections should now look like this.
 
@@ -200,6 +202,7 @@ Instructions of operations to be performed before the participant arrival, **bef
     
 - [ ] Configure the display settings of the laptop to mirror outputs and set a resolution of 800x600 for both screens.
 - [ ] Double check that the IP address corresponding to the ethernet interface of the *{{ secrets.hosts.psychopy | default("███") }}* laptop is correct. You can either run `ifconfig -a` or use the GUI. Make sure the IP/mask is **100.1.1.2/24**, and the protocol is IP version 4. Execute `ping 100.1.1.1` to see if the ET is responding to echoes.
+- [ ] Check that the service to synchronize the triggers is on with `sudo systemctl status forward-trigger`. If not, run `sudo systemctl status forward-trigger` and recheck the status.
 - [ ] Check that you can send trigger events manually:
     - [ ] Enter the "Synchronization" menu by selecting it and pushing the enter button (&#x25CF;).
     - [ ] Hit the down arrow button (&#x25BC;) until you find "Send trigger"

--- a/docs/data-collection/pre-session.md
+++ b/docs/data-collection/pre-session.md
@@ -192,7 +192,10 @@ Instructions of operations to be performed before the participant arrival, **bef
     
         ![switch_screen](../assets/images/screen_switch.jpg)
       
-- [ ] Connect the NEUROSPEC adapter (pink USB cable) to one of the USB port of the laptop *{{ secrets.hosts.psychopy | default("███") }}*. **This cable must always be connected last.**
+- [ ] Connect the MMBT-S Trigger Interface Box adapter (pink USB cable) to one of the USB ports of the laptop *{{ secrets.hosts.psychopy | default("███") }}*.
+    ![neurospec](../assets/images/neurospec.jpg)
+    
+    !!! danger "The MMBT-S Trigger Interface MUST be connected to the laptop AFTER the trigger USB cable coming from the SyncBox. "
 
 - Your laptop connections should now look like this.
 

--- a/docs/data-collection/pre-session.md
+++ b/docs/data-collection/pre-session.md
@@ -63,8 +63,6 @@ Instructions of operations to be performed before the participant arrival, **bef
     ![mac_setup](../assets/images/mac_setup.png) 
 - [ ] Connect one end of the parallel cable on the parallel plug on the back side of the STP100D unit of the BIOPAC and the other end to the parallel port of the NEUROSPEC parallel-to USB-converter.
     ![biopac-parallel-plug](../assets/images/biopac-parallel-plug.jpg "BIOPAC back side")
-    ![neurospec](../assets/images/neurospec.jpg) ** Do not connect the NEUROSPEC parallel-to USB-converter to *{{ secrets.hosts.psychopy | default("███") }}* now. It must always be connected after the USB cable of the sync box.**
-
 
     ![neurospec_usb](../assets/images/neurospec_usb.jpg)
 

--- a/docs/data-collection/pre-session.md
+++ b/docs/data-collection/pre-session.md
@@ -61,7 +61,7 @@ Instructions of operations to be performed before the participant arrival, **bef
 - [ ] Plug in the Ethernet (the plug is on the back side of the BIOPAC) to the multiport adapter connected to the computer *{{ secrets.hosts.oesteban | default("███") }}*.
     ![biopack-back](../assets/images/biopack-back.jpg "BIOPAC back side")
     ![mac_setup](../assets/images/mac_setup.png) 
-- [ ] Connect one end of the parallel cable on the parallel plug on the back side of the STP100D unit of the BIOPAC and the other end to the parallel port of the NEUROSPEC parallel-to USB-converter.
+- [ ] Connect the parallel cable to the 25-pin socket at the back of the SPT100D of the BIOPAC and to the parallel port of the MMBT-S Trigger Interface Box adapter (N-shaped pink box).
     ![biopac-parallel-plug](../assets/images/biopac-parallel-plug.jpg "BIOPAC back side")
 
     ![neurospec_usb](../assets/images/neurospec_usb.jpg)
@@ -207,7 +207,7 @@ Instructions of operations to be performed before the participant arrival, **bef
 
     !!! warning "If the service is down, manually force its start"
     
-        - [ ] Run `sudo systemctl status forward-trigger`
+        - [ ] Run `sudo systemctl start forward-trigger`
         - [ ] Recheck the status with `sudo systemctl status forward-trigger`.
     
     !!! important "These commands are executed with `sudo`"


### PR DESCRIPTION
 - At startup, the daemon checks if the trigger box is plugged in, throws an error and stops if this is not the case.
 - Add a check in the SOPs for the status of the daemon and precise the order in which to plug the USB cables.