### PR TITLE
ENH: improve order of tasks

### DIFF
--- a/docs/data-collection/scanning-notes.md
+++ b/docs/data-collection/scanning-notes.md
@@ -80,3 +80,11 @@ Adjust settings by pressing the respective button and then turning the central k
 - [ ] Use the fan :fontawesome-solid-fan: button (5) to adjust the ventilation in the scanning room.
 
 !!! warning "The central knob (button 1) will turn off the alarm if pushed when the alarm is on"
+
+### Standard extraction of the participant
+
+There are two options to extract the participant, when the session has concluded or within the session if the participant needs to be extracted and there is no emergency (e.g., in case of technical error the scanner does not permit continuing the session and it needs to be aborted).
+
+| ![take_table_down](../assets/images/take_table_down.png) | ![quick_return](../assets/images/quick_return.png) |
+|:--:|:--:|
+| *The participant can be extracted by pressing the extraction button (bottom arrow in the leftmost picture) and then genly rolling the central knob. Alternatively, you can just press the* Home :fontawesome-solid-house: *button (rightmost picture).* {: colspan=2} |

--- a/docs/data-collection/scanning.md
+++ b/docs/data-collection/scanning.md
@@ -237,14 +237,24 @@
 - [ ] While it is running, determine whether there is enough time to run the anatomical T2-weighted run. If so, [adjust the FoV](scanning-notes.md#setting-the-fov) for the following sequence.
 - [ ] Once the sequence is over, you need to stop manually the psychopy task by pressing the key <span class="keypress">t</span> on the keyboard (as fast as possible to avoid collecting more data than needed).
 
-## Concluding the session
+
 !!! warning "ONLY if time permits"
 
     - [ ] Launch the `anat-T2w__flair` protocol by pressing *Continue* (**⯈**)
+
+## Concluding the session
 
 - [ ] Inform the participant:
 
     ???+ quote "Session is finished"
         Thanks [NAME], the session has concluded and we will shortly let you out of the scanner.
+
+!!! warning "These operations may be done during the T2w acquisition"
+
+    - [ ] Stop the *AcqKnowledge* recording on the *{{ secrets.hosts.acqknowledge | default("███") }}* computer.
+    - [ ] Switch the BIOPAC MP160 module off.
+    - [ ] Turn off the pump of the GA.
+    - [ ] Switch the GA off.
+    - [ ] Put the exhaust and inlet caps back.
 
 - [ ] The exam is over, you can proceed with the [tear-down protocol](./tear-down.md).

--- a/docs/data-collection/tear-down.md
+++ b/docs/data-collection/tear-down.md
@@ -81,7 +81,7 @@
     - [ ] Insert a USB key into *{{ secrets.hosts.psychopy | default("███") }}* and save the experiment from AcqKnowledge.
     - [ ] Upload to a pre-designated drop-box (e.g., using Dropbox)
 - [ ] Press <span class="keypress">Ctrl</span>+<span class="keypress">Alt</span>+<span class="keypress">Q</span> on the ET PC Tower to exit the EyeLink 1000 Plus Host PC application and click on the <span class="keypress">Shutdown</span> button from the **File Manager** toolbar.
-- [ ] Switch off laptop and ET PC Tower. Plug back the sync box and the VGA projector where they were.
+- [ ] Switch off the laptop. Plug back the sync box and the VGA projector where they were.
 - [ ] Fix the rolled cable with the scotch on the ET PC Tower.
 - [ ] Turn off the pump of the GA, then switch the GA off. **DO NOT PUT THE CAP IN WHILE THE PUMP IS ON.**
 - [ ] Remove the cables connected to the BIOPAC and the GA and store them in the boxes in their original bags.

--- a/docs/data-collection/tear-down.md
+++ b/docs/data-collection/tear-down.md
@@ -36,9 +36,8 @@
 - [ ] Disconnect the GA and RB tubes.
 
 - [ ] **With someone outside in the control room**:
-    - [ ] Carefully extract the cables (fiber and power of the ET) back through the access tube.
-    - [ ] Extract the RB and the GA tubes from the room.
-
+    - [ ] Carefully extract the cables (fiber and power of the ET) back through the access tube. 
+  
 - [ ] **Carefully remove the infrared mirror**:
     - [ ] Enter again the scanner room with the plastic container of the mirror and leave it prepared on the bed.
     - [ ] Separate the mirror frame from the upper part of the head coil and lay it on the bed.
@@ -100,4 +99,3 @@
 - [ ] Turn off the control station ({{ secrets.hosts.console_right | default("███") }}, the computer on the right side of the control desk)
 - [ ] Push the blue button displaying an overdotted circle and the **SYSTEM OFF** label above, which is found right above the key
 - [ ] Turn the key into the *closed lock* position (:fontawesome-solid-lock:)
-

--- a/docs/data-collection/tear-down.md
+++ b/docs/data-collection/tear-down.md
@@ -2,7 +2,7 @@
 ## Showing the participant out
 
 - [ ] Extract the bed from the scanner's bore using the scanner's control wheel.
-    The home (:fontawesome-solid-house:) button can be used to bring the bed out.
+    The home (:fontawesome-solid-house:) button can alternatively be used to bring the bed out.
 
 | ![take_table_down](../assets/images/take_table_down.png) |
 |:--:|

--- a/docs/data-collection/tear-down.md
+++ b/docs/data-collection/tear-down.md
@@ -2,7 +2,7 @@
 ## Showing the participant out
 
 - [ ] Extract the bed from the scanner's bore using the scanner's control wheel.
-    The home button can be used to bring the bed out.
+    The home (:fontawesome-solid-house:) button can be used to bring the bed out.
 
 | ![take_table_down](../assets/images/take_table_down.png) |
 |:--:|
@@ -28,7 +28,16 @@
 - [ ] Give the participant the corresponding compensation for the participation and transportation.
 - [ ] Ask the participant to sign the receipt of the amount of the financial compensation.
 
+!!! important "To boost efficiency, two people can work simultaneously on the following steps — one inside the scanning room and the other outside. They can follow the designated sections [inside the scanning room](#after-scan-inside-the-scanner-room) and [outside the scanning room](#after-scan-outside-the-scanner-room) in parallel."
+
 ## AFTER SCAN, inside the scanner room
+
+- [ ] Unplug the two cables connected to the ET (signal and power). Put those extremities aside far from the scanner.
+- [ ] Disconnect the GA and RB tubes.
+
+- [ ] **With someone outside in the control room**:
+    - [ ] Carefully extract the cables (fiber and power of the ET) back through the access tube.
+    - [ ] Extract the RB and the GA tubes from the room.
 
 - [ ] **Carefully remove the infrared mirror**:
     - [ ] Enter again the scanner room with the plastic container of the mirror and leave it prepared on the bed.
@@ -40,22 +49,9 @@
 
 - [ ] Cleaning up instrumentation:
     - [ ] Take the projector's screen off and store it in its designated shelf.
-    - [ ] Unplug the two cables connected to the ET (signal and power). Put those extremities aside far from the scanner.
-    - [ ] Take the ET back outside and put it in a stable place.
-    - [ ] Unscrew the ET lens, while **ALWAYS** keeping one hand under the lens while screwing/unscrewing it and put it back into its cover.
-
-    ![cover-mri-compatible-lens](../assets/images/cover-mri-compatible-lens.png "Cover MRI compatible lens")
-
-    - [ ] Put the cover, the ET base back in the fMRI box, **being extremely careful to not crush the mirror**.
-
-- [ ] Re-enter the scanning room.
+    - [ ] Take the ET outside and put it in a stable place.
     - [ ] Disconnect the ECG leads from the filter of the access panel, fold the cable and leave it prepared with the RB to take out of the room with other equipment.
     - [ ] Disconnect the last section of the cannula and dispose of it in the trash can.
-    - [ ] Take the ECG electrodes, the RB, and the plexiglas base outside to the control room.
-
-- [ ] **With someone outside in the control room**:
-    - [ ] Careful extract the cables (fiber and power of the ET) back through the access tube. The person outside will carefully roll them around being extremely careful, and place them in the rolling table of the ET computer.
-    - [ ] Extract the RB and the GA tubing from the room. Likewise, the person outside will carefully roll and store them.
 
 - [ ] **Clean-up of the scanning room**:
     - [ ] Put the sheet and the blanket inside the dirty linen bag (in the trash if used plastic sheets).
@@ -67,28 +63,32 @@
     - [ ] Plug back the head coil if you know the next exam will require that specific coil, or simply put it away with the other (head) coils on the shelf next to the scanner.
     - [ ] Take some cleaning napkins on the shelves in the MR room. Use them to clean the bed and the head coil (bottom and upper parts).
     - [ ] Lock the head coil back with its bottom part, do not plug the connectors.
-    - [ ] Put the bed back in place = push the "home" button on the scanner
-    - [ ] Put the wooden stopper of the main access tube back on the tube.
+    - [ ] Put the bed back in place = push the home (:fontawesome-solid-house:) button on the scanner
     - [ ] Everything that is removed for the experiment MUST be put back in place at the end of the experiment, i.e. position of the bed, coil, emergency button, ears padding.
+    - [ ] Take the ECG electrodes, the RB, and the plexiglass outside to the control room.
     - [ ] Exit and close the external door.
 
-## AFTER SCAN, outside scanner room
+## AFTER SCAN, outside the scanner room
 
-- [ ] Switch off the projector.
+- [ ] Help the person inside the scanning room to extract the cables and tubes.
+- [ ] Carefully roll the fiber and power cable of the ET, and place them in the rolling table of the ET PC Tower.
+- [ ] Carefully roll RB and the GA tubes and put them back in the GA and BIOPAC boxes.
+- [ ] Unscrew the ET lens, while **ALWAYS** keeping one hand under the lens while screwing/unscrewing it and put it back into its cover.
 
+  ![cover-mri-compatible-lens](../assets/images/cover-mri-compatible-lens.png "Cover MRI compatible lens")
+
+- [ ] Put the cover, the ET base back in the fMRI box, **being extremely careful to not crush the mirror**.
 - [ ] **Retrieve ET recordings** (from {{ secrets.hosts.psychopy | default("███") }}):
     - [ ] Insert a USB key into *{{ secrets.hosts.psychopy | default("███") }}* and save the experiment from AcqKnowledge.
     - [ ] Upload to a pre-designated drop-box (e.g., using Dropbox)
-- [ ] Press <span class="keypress">Ctrl</span>+<span class="keypress">Alt</span>+<span class="keypress">Q</span> on the ET's computer to exit the EyeLink 1000 Plus Host PC application and click on the <span class="keypress">Shutdown</span> button from the **File Manager** toolbar.
+- [ ] Press <span class="keypress">Ctrl</span>+<span class="keypress">Alt</span>+<span class="keypress">Q</span> on the ET PC Tower to exit the EyeLink 1000 Plus Host PC application and click on the <span class="keypress">Shutdown</span> button from the **File Manager** toolbar.
 - [ ] Switch off laptop and ET PC Tower. Plug back the sync box and the VGA projector where they were.
-- [ ] Fix the rolled cable with the scotch on the PC Tower base.
+- [ ] Fix the rolled cable with the scotch on the ET PC Tower.
 - [ ] Turn off the pump of the GA, then switch the GA off. **DO NOT PUT THE CAP IN WHILE THE PUMP IS ON.**
 - [ ] Remove the cables connected to the BIOPAC and the GA and store them in the boxes in their original bags.
-- [ ] Take the ET, Remove (always with and hand under the lens) the MRI compatible LENS. Put it back to its contained inside the box.
-- [ ] Put back the regular Lens.
-- [ ] Bring back the box and the base at CIBM EEG lab. Put the keys back under old Nora's desk.
-- [ ] Fix the ET with the scotch at the chariot.
-- [ ] Bring back the chariot and the TMS laptop at the TMS lab
+- [ ] Bring back the fMRI, BIOPAC and GA boxes in {{ secrets.rooms.et_camera| default("███") }}.
+- [ ] Bring back the ET PC Tower and the plexiglas in {{ secrets.rooms.projector | default("███") }}
+- [ ] Switch off the projector.
 
 ## Turn off the MRI system if no more sessions are scheduled afterward
 

--- a/docs/data-collection/tear-down.md
+++ b/docs/data-collection/tear-down.md
@@ -56,7 +56,7 @@
 - [ ] Take the projector's screen off and store it in its designated shelf.
 - [ ] Disconnect the ECG cable from the filter of the access panel, roll the cable.
 
-### Reading the scanner for the next session
+### Readying the scanner for the next session
 
 !!! warning "Every setting altered for the experiment MUST be put back to its original status at the end of the experiment (e.g., position of the bed, coil, emergency button, padding elements, etc.)"
 

--- a/docs/data-collection/tear-down.md
+++ b/docs/data-collection/tear-down.md
@@ -110,9 +110,6 @@
 
 ### Finalizing with the ET's PC
 
-- [ ] **Retrieve ET recordings** (from {{ secrets.hosts.psychopy | default("███") }}):
-    - [ ] Insert a USB key into *{{ secrets.hosts.psychopy | default("███") }}*
-    - [ ] Upload to a pre-designated drop-box (e.g., using Dropbox)
 - [ ] Exit the EyeLink 1000 Plus Host PC application by pressing <span class="keypress">Ctrl</span>+<span class="keypress">Alt</span>+<span class="keypress">Q</span> on the ET PC and next click on the <span class="keypress">Shutdown</span> button from the **File Manager** toolbar.
 - [ ] Secure the rolled cable with the scotch tape on the ET PC Tower.
 - [ ] Take the ET PC Tower and the plexiglass back into room {{ secrets.rooms.projector | default("███") }}.

--- a/docs/data-collection/tear-down.md
+++ b/docs/data-collection/tear-down.md
@@ -36,7 +36,7 @@
 - [ ] Disconnect the GA and RB tubes.
 
 - [ ] **With someone outside in the control room**:
-    - [ ] Carefully extract the cables (fiber and power of the ET) back through the access tube. 
+    - [ ] Carefully extract the four cables one by one (the fiber and power of the ET, the tube of RB and the tube of the GA) back through the access tube. 
   
 - [ ] **Carefully remove the infrared mirror**:
     - [ ] Enter again the scanner room with the plastic container of the mirror and leave it prepared on the bed.

--- a/docs/data-collection/tear-down.md
+++ b/docs/data-collection/tear-down.md
@@ -1,27 +1,28 @@
 
 ## Showing the participant out
 
-- [ ] Extract the bed from the scanner's bore using the scanner's control wheel.
-    The home (:fontawesome-solid-house:) button can alternatively be used to bring the bed out.
+- [ ] Enter the scanner room, and announce yourself to the participant:
 
-| ![take_table_down](../assets/images/take_table_down.png) |
-|:--:|
-| ![quick_return](../assets/images/quick_return.png) |
+    !!! quote "Hi [NAME], thanks a lot for your collaboration. We will get you out in a second."
 
+- [ ] Extract the participant [following the standard procedure](scanning-notes.md#standard-extraction-of-the-participant).
 - [ ] Unplug the head coil from the bed connector, lift the lever that releases the upper part of the coil and put it aside (e.g., inside the bore or on a chair next to the scanner).
-- [ ] Release the air from the inflatable padding by pushing the release valve of the pump and take them away. Remove the disposable covers and throw them away in the trash can.
+- [ ] Remove the tape band across the coil and touching the participants forehead.
+- [ ] Lift the nasal cannula and put it away so the participant does not get tangled.
+- [ ] Assist the participant to remove the padding elements around their head.
 - [ ] Help the participant sit down.
-- [ ] Instruct the participant to remove the earplugs and dispose of them. Ask them about the experience:
+- [ ] Instruct the participant to remove the earplugs and dispose of them.
+- [ ] Ask them about the experience:
 
     ???+ quote "Get feedback about the session from the participant"
         [NAME], how was your experience?
         Have you been able to feel comfortable throughout the session?
         What advice, indication do you feel we could've provided you for a better experience?
 
-- [ ] Lift the nasal cannula and help the participant remove it from their head.
 - [ ] Disconnect the tube from the RB and then lift the velcro attachment to remove the RB.
 - [ ] Prepare the belt on the bed to be removed from the room when you show the participant out.
-- [ ] Disconnect the ECG leads
+- [ ] Help the participant carefully remove the ECG leads.
+- [ ] Disconnect the three ECG terminals from the cable and put them in their pouch.
 - [ ] Disconnect the last section of the cannula and dispose of it in the trash can.
 - [ ] Help the participant step down and accompany them out to the control room.
 - [ ] Help the participant recover their personal belongings and change clothes if necessary.
@@ -30,72 +31,100 @@
 - [ ] Give the participant the corresponding compensation for the participation and transportation.
 - [ ] Ask the participant to sign the receipt of the amount of the financial compensation.
 
-!!! important "The following steps are better done with two people"
-    One researcher operates **inside** the Scanning Room and the other one is **outside**, at the Control Room.
-    They will parallelize the designated steps below: [inside the scanning room](#after-scan-inside-the-scanner-room), and [outside the scanning room](#after-scan-outside-the-scanner-room).
 
-## AFTER SCAN, inside the scanner room
+## Clearing up the Scanning Room
+
+### ET arm, ET cables, infrared mirror and stimuli screen
 
 - [ ] Unplug the two cables (signal and power) connected to the ET arm.
-    Put those extremities aside far from the scanner.
+    Put their extremities aside far from the scanner.
 - [ ] Agree with another experimenter, who will exit the room, sit on the other side of the access tubes in the Control Room, and pull cables (fiber and power of the ET) and tubes (RB and GA) out of the room.
     At the same time, you carefully feed them so they do not suffer abrasion from touching the edges of the tube.
-- [ ] The experimenter currently outside in the Control Room will enter the Scanner Room with the plastic bag of the mirror and a fresh pair of gloves and will leave them prepared on the bed.
+
+    !!! warning "Extracting the cables and tubes requires two experimenters"
+
+- [ ] The experimenter currently outside in the Control Room will re-enter the Scanner Room with the plastic bag of the mirror and a fresh pair of gloves and will leave them prepared on the bed.
 - [ ] Remove the mirror frame from its rails mounted on the head coil and lay it on the bed.
 - [ ] Put the gloves on and detach the infrared mirror from the standard mirror.
+
+    !!! danger "The infrared mirror MUST be manipulated with clean gloves at all times."
+
 - [ ] Immediately insert the infrared mirror back into its plastic pouch.
 - [ ] Take the pouch containing the infrared mirror outside to the Control Room and place it back in its designated box, with extreme care.
 - [ ] Clean the standard mirror removing all residues of glue from the scotch tape.
 - [ ] Re-attach the mirror to the coil's frame.
-    - [ ] **PUT ON A NEW PAIR OF GLOVES**
-    - [ ] Remove the scotch tape holding the infrared mirror and **IMMEDIATELY** insert the mirror in its plastic bag.
-    - [ ] Take the mirror in its bag **OUT OF THE SCANNING ROOM** and place it back in the fMRI box, with extreme care.
-    - [ ] Re-enter the scanning room and clean the standard mirror removing all residues of glue from the scotch tape. Re-attach the mirror to its coil's frame.
-
-- [ ] Cleaning up instrumentation:
-    - [ ] Take the projector's screen off and store it in its designated shelf.
+- [ ] Take the projector's screen off and store it in its designated shelf.
 - [ ] Disconnect the ECG cable from the filter of the access panel, roll the cable.
-- [ ] Take the ET arm and the ECG cable outside to the Control Room.
-- [ ] Place the ET arm in a stable place.
-- [ ] Store the ECG cable in its designated box / storage.
+
+### Reading the scanner for the next session
+
+!!! warning "Every setting altered for the experiment MUST be put back to its original status at the end of the experiment (e.g., position of the bed, coil, emergency button, padding elements, etc.)"
+
+- [ ] Put the used bed-sheet and the blanket inside the soiled linen bag.
+
+    !!! important "Put them away in the trash if they are disposable"
+
+- [ ] Dispose all single-use sanitary protections.
+- [ ] Put the pillows back in their designated storage places.
+- [ ] Remove the head coil and put it in the scanner's bore.
+- [ ] Remove the back padding elements and put them back in their designated storage.
+- [ ] Reinstall the spine coil.
+- [ ] Wipe the bed and the head coil (bottom and upper parts).
+
+    !!! info "Cleaning wipes are available on shelf in the Scanning Room."
+
+- [ ] Lock the head coil back with its bottom part without plugging the connectors.
+- [ ] Put the head coil away with the other head-coils on the shelf next to the scanner.
+
+    !!! important "If the next user is already there or you know the current coil will be also used in the next session, plug it back into the bed socket."
+
+- [ ] Return the bed to its *Home* position by pressing the :fontawesome-solid-house: button ([more info](scanning-notes.md#standard-extraction-of-the-participant)).
+- [ ] Take the ET arm outside to the Control Room and place it in a stable place.
+- [ ] Take the ECG electrodes, ECG cable, the RB, and the plexiglass panel outside to the control room.
+- [ ] Exit and close the external door.
+
+## Clearing up the Control Room
+
+### Finalize the *boxing* of the ET elements
+- [ ] Put the lens cover.
+- [ ] Unscrew the ET lens, while **ALWAYS** keeping one hand under the lens while screwing/unscrewing it and put it back into its pouch.
+    ![cover-mri-compatible-lens](../assets/images/cover-mri-compatible-lens.png "Cover MRI compatible lens")
 - [ ] Store the ET arm in its designated box.
 
-- [ ] **Clean-up of the scanning room**:
-    - [ ] Put the sheet and the blanket inside the dirty linen bag (in the trash if used plastic sheets).
-    - [ ] Dispose all single-use sanitary protections.
-    - [ ] Put the pillows back in place.
-    - [ ] Remove the head coil and put it in the scanner's bore.
-    - [ ] Remove the back padding elements and put them back in their designated storage.
-    - [ ] Reinstall the spine coil.
-    - [ ] Plug back the head coil if you know the next exam will require that specific coil, or simply put it away with the other (head) coils on the shelf next to the scanner.
-    - [ ] Take some cleaning napkins on the shelves in the MR room. Use them to clean the bed and the head coil (bottom and upper parts).
-    - [ ] Lock the head coil back with its bottom part, do not plug the connectors.
-    - [ ] Put the bed back in place = push the home (:fontawesome-solid-house:) button on the scanner
-    - [ ] Everything that is removed for the experiment MUST be put back in place at the end of the experiment, i.e. position of the bed, coil, emergency button, ears padding.
-    - [ ] Take the ECG electrodes, the RB, and the plexiglass outside to the control room.
-    - [ ] Exit and close the external door.
+    !!! danger "REMEMBER | the infrared mirror is inside that box already: DO NOT crush the mirror."
 
-## AFTER SCAN, outside the scanner room
+### Finalize the *boxing* of other physiological recording instruments
 
-- [ ] Help the person inside the scanning room to extract the cables and tubes.
-- [ ] Carefully roll the fiber and power cable of the ET, and place them in the rolling table of the ET PC Tower.
-- [ ] Carefully roll RB and the GA tubes and put them back in the GA and BIOPAC boxes.
-- [ ] Unscrew the ET lens, while **ALWAYS** keeping one hand under the lens while screwing/unscrewing it and put it back into its cover.
+- [ ] Store the ECG cable and the pouch with the ECG leads in its designated box / storage.
+- [ ] Carefully roll the fiber and power cable of the ET, and place them in the rolling table of the ET PC.
+- [ ] Carefully roll the GA tube and put it in its designated bag.
+- [ ] Carefully roll the RB tube and put it in its designated bag.
+- [ ] Disconnect the MMBT-S Interface, and the two corresponding cables (pink USB, 25-pin parallel), and insert them in their designated bags.
+- [ ] Remove the cable connecting the GA to the AMI100D module of the BIOPAC, roll it and put it in its designated bag.
+- [ ] Put the GA and the corresponding cables in the designated box.
+- [ ] Disconnect and bag the remaining cables connected to the BIOPAC:
+    - [ ] Ethernet to the *{{ secrets.hosts.acqknowledge | default("███") }}* computer.
+    - [ ] Power cord.
+- [ ] Retrieve and bag the *AcqKnowledge USB License Key* from the *{{ secrets.hosts.acqknowledge | default("███") }}* computer.
+- [ ] Store the *fMRI box*, BIOPAC and GA boxes back in room {{ secrets.rooms.et_camera| default("███") }}.
 
-  ![cover-mri-compatible-lens](../assets/images/cover-mri-compatible-lens.png "Cover MRI compatible lens")
+### Finalizing with the ET's PC
 
-- [ ] Put the cover, the ET base back in the fMRI box, **being extremely careful to not crush the mirror**.
 - [ ] **Retrieve ET recordings** (from {{ secrets.hosts.psychopy | default("███") }}):
-    - [ ] Insert a USB key into *{{ secrets.hosts.psychopy | default("███") }}* and save the experiment from AcqKnowledge.
+    - [ ] Insert a USB key into *{{ secrets.hosts.psychopy | default("███") }}*
     - [ ] Upload to a pre-designated drop-box (e.g., using Dropbox)
-- [ ] Press <span class="keypress">Ctrl</span>+<span class="keypress">Alt</span>+<span class="keypress">Q</span> on the ET PC Tower to exit the EyeLink 1000 Plus Host PC application and click on the <span class="keypress">Shutdown</span> button from the **File Manager** toolbar.
-- [ ] Switch off the laptop. Plug back the sync box and the VGA projector where they were.
-- [ ] Fix the rolled cable with the scotch on the ET PC Tower.
-- [ ] Turn off the pump of the GA, then switch the GA off. **DO NOT PUT THE CAP IN WHILE THE PUMP IS ON.**
-- [ ] Remove the cables connected to the BIOPAC and the GA and store them in the boxes in their original bags.
-- [ ] Bring back the fMRI, BIOPAC and GA boxes in {{ secrets.rooms.et_camera| default("███") }}.
-- [ ] Bring back the ET PC Tower and the plexiglas in {{ secrets.rooms.projector | default("███") }}.
-- [ ] Switch off the projector.
+- [ ] Exit the EyeLink 1000 Plus Host PC application by pressing <span class="keypress">Ctrl</span>+<span class="keypress">Alt</span>+<span class="keypress">Q</span> on the ET PC and next click on the <span class="keypress">Shutdown</span> button from the **File Manager** toolbar.
+- [ ] Secure the rolled cable with the scotch tape on the ET PC Tower.
+- [ ] Take the ET PC Tower and the plexiglass back into room {{ secrets.rooms.projector | default("███") }}.
+- [ ] Switch the projector off before exiting room {{ secrets.rooms.projector | default("███") }}.
+
+### Finalizing the support laptops
+- [ ] Unplug from {{ secrets.hosts.psychopy | default("███") }} the USB cable coming from the SyncBox.
+- [ ] Switch the SyncBox off, and make sure you leave it connected exactly as you found it.
+- [ ] Unplug from {{ secrets.hosts.psychopy | default("███") }} the HDMI cable from the display switch.
+- [ ] Check that you leave the display switch as you found it.
+- [ ] Switch off the {{ secrets.hosts.psychopy | default("███") }} computer.
+- [ ] Exit the *Amphetamine* session and lock the screen of the {{ secrets.hosts.acqknowledge | default("███") }} computer.
 
 ## Turn off the MRI system if no more sessions are scheduled afterward
 

--- a/docs/data-collection/tear-down.md
+++ b/docs/data-collection/tear-down.md
@@ -20,7 +20,9 @@
 
 - [ ] Lift the nasal cannula and help the participant remove it from their head.
 - [ ] Disconnect the tube from the RB and then lift the velcro attachment to remove the RB.
+- [ ] Prepare the belt on the bed to be removed from the room when you show the participant out.
 - [ ] Disconnect the ECG leads
+- [ ] Disconnect the last section of the cannula and dispose of it in the trash can.
 - [ ] Help the participant step down and accompany them out to the control room.
 - [ ] Help the participant recover their personal belongings and change clothes if necessary.
 - [ ] Solicit more feedback on participant's comfort for future sessions.

--- a/docs/data-collection/tear-down.md
+++ b/docs/data-collection/tear-down.md
@@ -86,7 +86,7 @@
 - [ ] Turn off the pump of the GA, then switch the GA off. **DO NOT PUT THE CAP IN WHILE THE PUMP IS ON.**
 - [ ] Remove the cables connected to the BIOPAC and the GA and store them in the boxes in their original bags.
 - [ ] Bring back the fMRI, BIOPAC and GA boxes in {{ secrets.rooms.et_camera| default("███") }}.
-- [ ] Bring back the ET PC Tower and the plexiglas in {{ secrets.rooms.projector | default("███") }}
+- [ ] Bring back the ET PC Tower and the plexiglas in {{ secrets.rooms.projector | default("███") }}.
 - [ ] Switch off the projector.
 
 ## Turn off the MRI system if no more sessions are scheduled afterward

--- a/docs/data-collection/tear-down.md
+++ b/docs/data-collection/tear-down.md
@@ -28,19 +28,23 @@
 - [ ] Give the participant the corresponding compensation for the participation and transportation.
 - [ ] Ask the participant to sign the receipt of the amount of the financial compensation.
 
-!!! important "To boost efficiency, two people can work simultaneously on the following steps — one inside the scanning room and the other outside. They can follow the designated sections [inside the scanning room](#after-scan-inside-the-scanner-room) and [outside the scanning room](#after-scan-outside-the-scanner-room) in parallel."
+!!! important "The following steps are better done with two people"
+    One researcher operates **inside** the Scanning Room and the other one is **outside**, at the Control Room.
+    They will parallelize the designated steps below: [inside the scanning room](#after-scan-inside-the-scanner-room), and [outside the scanning room](#after-scan-outside-the-scanner-room).
 
 ## AFTER SCAN, inside the scanner room
 
-- [ ] Unplug the two cables connected to the ET (signal and power). Put those extremities aside far from the scanner.
-- [ ] Disconnect the GA and RB tubes.
-
-- [ ] **With someone outside in the control room**:
-    - [ ] Carefully extract the four cables one by one (the fiber and power of the ET, the tube of RB and the tube of the GA) back through the access tube. 
-  
-- [ ] **Carefully remove the infrared mirror**:
-    - [ ] Enter again the scanner room with the plastic container of the mirror and leave it prepared on the bed.
-    - [ ] Separate the mirror frame from the upper part of the head coil and lay it on the bed.
+- [ ] Unplug the two cables (signal and power) connected to the ET arm.
+    Put those extremities aside far from the scanner.
+- [ ] Agree with another experimenter, who will exit the room, sit on the other side of the access tubes in the Control Room, and pull cables (fiber and power of the ET) and tubes (RB and GA) out of the room.
+    At the same time, you carefully feed them so they do not suffer abrasion from touching the edges of the tube.
+- [ ] The experimenter currently outside in the Control Room will enter the Scanner Room with the plastic bag of the mirror and a fresh pair of gloves and will leave them prepared on the bed.
+- [ ] Remove the mirror frame from its rails mounted on the head coil and lay it on the bed.
+- [ ] Put the gloves on and detach the infrared mirror from the standard mirror.
+- [ ] Immediately insert the infrared mirror back into its plastic pouch.
+- [ ] Take the pouch containing the infrared mirror outside to the Control Room and place it back in its designated box, with extreme care.
+- [ ] Clean the standard mirror removing all residues of glue from the scotch tape.
+- [ ] Re-attach the mirror to the coil's frame.
     - [ ] **PUT ON A NEW PAIR OF GLOVES**
     - [ ] Remove the scotch tape holding the infrared mirror and **IMMEDIATELY** insert the mirror in its plastic bag.
     - [ ] Take the mirror in its bag **OUT OF THE SCANNING ROOM** and place it back in the fMRI box, with extreme care.
@@ -48,9 +52,11 @@
 
 - [ ] Cleaning up instrumentation:
     - [ ] Take the projector's screen off and store it in its designated shelf.
-    - [ ] Take the ET outside and put it in a stable place.
-    - [ ] Disconnect the ECG leads from the filter of the access panel, fold the cable and leave it prepared with the RB to take out of the room with other equipment.
-    - [ ] Disconnect the last section of the cannula and dispose of it in the trash can.
+- [ ] Disconnect the ECG cable from the filter of the access panel, roll the cable.
+- [ ] Take the ET arm and the ECG cable outside to the Control Room.
+- [ ] Place the ET arm in a stable place.
+- [ ] Store the ECG cable in its designated box / storage.
+- [ ] Store the ET arm in its designated box.
 
 - [ ] **Clean-up of the scanning room**:
     - [ ] Put the sheet and the blanket inside the dirty linen bag (in the trash if used plastic sheets).

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -56,9 +56,6 @@ span.flip {
   transform: scale(-1, -1);
 }
 
-/*:root {
-  --md-admonition-icon--thanks: fa-thumbs-up;
-}*/
 .md-typeset .admonition.thanks,
 .md-typeset details.thanks {
   border-color: rgb(43, 155, 70);
@@ -72,4 +69,19 @@ span.flip {
   background-color: rgb(43, 155, 70);
   -webkit-mask-image: var(--md-admonition-icon--thanks);
           mask-image: var(--md-admonition-icon--thanks);
+}
+
+.md-typeset .admonition.important,
+.md-typeset details.important {
+/*  border-color: rgb(43, 155, 70);*/
+}
+.md-typeset .important > .admonition-title,
+.md-typeset .important > summary {
+/*  background-color: rgba(43, 155, 70, 0.1);*/
+}
+.md-typeset .important > .admonition-title::before,
+.md-typeset .important > summary::before {
+/*  background-color: rgb(43, 155, 70);*/
+  -webkit-mask-image: var(--md-admonition-icon--important);
+          mask-image: var(--md-admonition-icon--important);
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,8 @@ theme:
     admonition:
       thanks: octicons/code-of-conduct-16
       quote: fontawesome/solid/comment-dots
+      danger: fontawesome/solid/biohazard
+      important: fontawesome/solid/circle-exclamation
 
 plugins:
   - search


### PR DESCRIPTION
- Change the order of tasks to parallelize work inside and outside the scanning room. 
- Make terminology consistent.
- Fix some typos and weird statements.
closes #149