### PR TITLE
ENH: Added a safety check for the desiccant chamber color

### DIFF
--- a/docs/data-collection/intro.md
+++ b/docs/data-collection/intro.md
@@ -106,11 +106,11 @@ The above graph can be broken down as follows:
 
     !!! danger "Make sure you understand the switching on and off procedures described in these SOPs"
 
-    The input to the GA must be connected through a DM-060-24 dessicant chamber and a MLA0110 flow valve and a MLA0343 drying tube:
+    The input to the GA must be connected through a DM-060-24 desiccant chamber and a MLA0110 flow valve and a MLA0343 drying tube:
 
     ![desiccant_chamber](../assets/images/desiccant_chamber.png)
 
-    !!! warning "The MLA0343 drying tube and the DM-060-24 dessicant chamber MUST be replaced when their inside color turns into pink."
+    !!! warning "The MLA0343 drying tube and the DM-060-24 desiccant chamber MUST be replaced when their inside color turns into pink."
 
     Finally, make sure to watch the following video:
     <video id="wistia_simple_video_119" crossorigin="anonymous" style="background: transparent; display: block; height: 100%; max-height: none; max-width: none; position: static; visibility: visible; width: 100%; object-fit: fill;" aria-label="Video" src="https://embed-ssl.wistia.com/deliveries/5e08ccab25ab45382329671a82dfe5123f6e840e/file.mp4" playsinline="" preload="metadata" type="video/mp4" x-webkit-airplay="allow" controls>

--- a/docs/data-collection/pre-session.md
+++ b/docs/data-collection/pre-session.md
@@ -110,6 +110,8 @@ Instructions of operations to be performed before the participant arrival, **bef
 ![RB_connection](../assets/images/RB_connection.jpg "RB_connection")
 - [ ] Go back to the control room and connect the proximal end of the cannula extension tube to one plug of the desiccant chamber (which one is not important). Connect the MLA0110 inline filter to the other plug of the desiccant chamber. Connect the MLA0343 drying tube to the MLA0110 inline filter.
 
+    !!! warning "Make sure that the inside color of the drying tube and the desiccant chamber have not turned pink. They must be replaced if it is the case."
+
 ![desiccant_chamber](../assets/images/desiccant_chamber.png)
 
 - [ ] Remove the cap of the gas input (Sample In, front panel of the GA) and connect the MLA0110 inline filter to it. The inline filter MUST be replaced after some ten sessions.


### PR DESCRIPTION
- Added a reminder in `pre-session.md` that the color of the desiccant chamber and drying tube must be replaced if they have turned pink (closes #136 )
- Fixed typos in `intro.md` (de**ss**icant -> desi**cc**ant)