### PR TITLE
enh: Add script to automatize save and push WIP DO NOT MERGE

### DIFF
--- a/code/synchronization/monitor-changes.sh
+++ b/code/synchronization/monitor-changes.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+
+source activate mydataladenv
+
+cd /home/common/workspace/HCPh-data/Psychopy/
+
+while true; do
+    inotifywait -e create,modify -r .
+    datalad save -m 'Auto commit from inotify' && datalad push -r --to hos70297-psychopy
+done
+
+source deactivate
+


### PR DESCRIPTION
This script activates an Anaconda environment, monitors the datalad folder in which we save the Psychopy output for file changes using inotifywait, and performs datalad operations (save and push) in response to changes. It ensures data synchronization while the Anaconda environment is active. closes #177 