### PR TITLE
FIX: *Psychopy* installation

### DIFF
--- a/docs/data-collection/intro.md
+++ b/docs/data-collection/intro.md
@@ -168,7 +168,7 @@ Most of what is described in the present SOPs addresses the *Reliability Imaging
     The stimuli presentation laptop ({{ secrets.hosts.psychopy | default("███") }}) will execute four experiments, which will allow the synchronization of all devices by sending the adequate signals at their predesignated times and also present visual stimuli with the scanner's projector.
     The lengths of the four *Psychopy experiments* should be:
 
-    * {{ settings.psychopy.tasks.dwi }} ➜ <mark>**{{ settings.mri.timings.dwi }}**</mark>,
-    * {{ settings.psychopy.tasks.func_qct }} ➜ <mark>**{{ settings.mri.timings.func_qct }}**</mark>,
-    * {{ settings.psychopy.tasks.func_rest }} ➜ <mark>**{{ settings.mri.timings.func_rest }}**</mark>, and
-    * {{ settings.psychopy.tasks.func_bht }} ➜ <mark>**{{ settings.mri.timings.func_bht }}**</mark>.
+    * `{{ settings.psychopy.tasks.dwi }}` ➜ <mark>**{{ settings.mri.timings.dwi }}**</mark>,
+    * `{{ settings.psychopy.tasks.func_qct }}` ➜ <mark>**{{ settings.mri.timings.func_qct }}**</mark>,
+    * `{{ settings.psychopy.tasks.func_rest }}` ➜ <mark>**{{ settings.mri.timings.func_rest }}**</mark>, and
+    * `{{ settings.psychopy.tasks.func_bht }}` ➜ <mark>**{{ settings.mri.timings.func_bht }}**</mark>.

--- a/docs/data-collection/pre-session.md
+++ b/docs/data-collection/pre-session.md
@@ -29,14 +29,11 @@ Instructions of operations to be performed before the participant arrival, **bef
 - [ ] Open psychopy 3 by typing `psychopy`
 - [ ] Load in the different experiments and check for proper functioning:
     - [ ] {{ settings.psychopy.tasks.func_rest }} (resting-state fMRI):
-        - [ ] time it to [confirm the length](intro.md#task-timing), and
         - [ ] check that the movie is played.
     - [ ] {{ settings.psychopy.tasks.func_bht }} (breath-holding task, BHT):
-        - [ ] time it to [confirm the length](intro.md#task-timing), and
-        - [ ] check that the movie is played.
+        - [ ] check that the task runs properly.
     - [ ] {{ settings.psychopy.tasks.func_qct }} (quality-control task, QCT):
-        - [ ] time it to [confirm the length](intro.md#task-timing), and
-        - [ ] check that the movie is played.
+        - [ ] check that the task runs properly.
 
 ## Documentation and other non-experimental devices
 

--- a/docs/data-collection/pre-session.md
+++ b/docs/data-collection/pre-session.md
@@ -28,11 +28,11 @@ Instructions of operations to be performed before the participant arrival, **bef
 - [ ] On the *{{ secrets.hosts.psychopy | default("███") }}* laptop, open a terminal and execute `conda deactivate`.
 - [ ] Open psychopy 3 by typing `psychopy`
 - [ ] Load in the different experiments and check for proper functioning:
-    - [ ] {{ settings.psychopy.tasks.func_rest }} (resting-state fMRI):
+    - [ ] `{{ settings.psychopy.tasks.func_rest }}` (resting-state fMRI):
         - [ ] check that the movie is played.
-    - [ ] {{ settings.psychopy.tasks.func_bht }} (breath-holding task, BHT):
+    - [ ] `{{ settings.psychopy.tasks.func_bht }}` (breath-holding task, BHT):
         - [ ] check that the task runs properly.
-    - [ ] {{ settings.psychopy.tasks.func_qct }} (quality-control task, QCT):
+    - [ ] `{{ settings.psychopy.tasks.func_qct }}` (quality-control task, QCT):
         - [ ] check that the task runs properly.
 
 ## Documentation and other non-experimental devices

--- a/docs/data-collection/preliminary.md
+++ b/docs/data-collection/preliminary.md
@@ -130,6 +130,12 @@ This block describes how to prepare a laptop with a running *Psychopy 3* install
     ```
     pip3 install attrdict py2app bdist_mpkg
     ```
+- [ ] Install wxPython. Careful to replace the ubuntu version with the one corresponding to your system (you can check which Ubuntu version is installed on your system by running `lsb_release -a` in the terminal)
+    ```
+    pip3 install -U \
+        -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04 \
+        wxPython
+    ```
 - [ ] Install Psychopy using the following command:
     ```
     pip3 install -e .

--- a/docs/data-collection/preliminary.md
+++ b/docs/data-collection/preliminary.md
@@ -140,7 +140,11 @@ This block describes how to prepare a laptop with a running *Psychopy 3* install
     ```
     pip3 install -e .
     ```
-- [ ] Open Psychopy, open the experiment-files corresponding to each task:
+- [ ] Open Psychopy, open the experiment-files corresponding to each task by typing the following command in the terminal:
+    ```
+    psychopy your_experiment.psyexp
+    ```
+- [ ] For each task, check the following:
     - [ ] {{ settings.psychopy.tasks.func_qct }} (positive-control task, QCT) :
         - [ ] time it to confirm the length, and
         - [ ] check the task runs properly.

--- a/docs/data-collection/preliminary.md
+++ b/docs/data-collection/preliminary.md
@@ -96,6 +96,14 @@ Once finalized the protocol design, it will be *frozen* and it cannot be changed
 ### Install *Psychopy* for stimuli presentation and development
 This block describes how to prepare an environment with a running *Psychopy 3* installation.
 
+!!! warning "Multiple screens"
+
+    If you want to use multiple screens, install the corresponding libxcb extension:
+
+    ``` shell
+    sudo apt-get install libxcb-xinerama0
+    ```
+
 - [ ] Clone the [*Psychopy* repository](https://github.com/psychopy/psychopy.git):
     ``` shell
     git clone git@github.com:psychopy/psychopy.git
@@ -109,9 +117,13 @@ This block describes how to prepare an environment with a running *Psychopy 3* i
     ``` shell
     conda deactivate
     ```
-- [ ] Update pip to the latest version:
+- [ ] Update *Pypi* to the latest version:
     ``` shell
-    python3 -m pip install --upgrade pip
+    python3 -m pip install -U pip
+    ```
+- [ ] Update *Numpy* to the latest version:
+    ``` shell
+    python3 -m pip install -U numpy
     ```
 - [ ] Install bdist_mpkg, py2app and attrdict:
     ``` shell
@@ -166,6 +178,21 @@ This block describes how to prepare an environment with a running *Psychopy 3* i
     A quick attempt to solve this would be adding our user to the `video` group.
 
     However, that is unlikely to work out so you'll need to take more actions (see [this](https://github.com/mmatl/pyrender/issues/13), and [this](https://askubuntu.com/questions/1255841/how-do-i-fix-the-glxinfo-badvalue-error-on-ubuntu-18-04))
+
+??? bug "*Psychopy* crashes when trying to run a experiment: `qt.qpa.plugin: Could not load the Qt platform plugin 'xcb'`"
+
+    If you installed `libxcb-xinerama0`, or you don't have multiple screens, first try:
+
+    ``` shell
+    python3 -m pip uninstall opencv-python
+    python3 -m pip install opencv-python-headless
+    ```
+
+    If that doesn't work, try a brute force solution by installing libxcb fully:
+
+    ``` shell
+    sudo apt-get install libxcb-*
+    ```
 
 ### Preparing the *Stimuli presentation laptop* ({{ secrets.hosts.psychopy | default("███") }})
 

--- a/docs/data-collection/preliminary.md
+++ b/docs/data-collection/preliminary.md
@@ -100,6 +100,7 @@ This block describes how to prepare a laptop with a running *Psychopy 3* install
 
 #### Stimuli presentation with *psychopy*
 
+- [ ] Log on *{{ secrets.hosts.psychopy | default("███") }}* with the username *{{ secrets.login.username_psychopy| default("███") }}* and password `{{ secrets.login.password_psychopy| default("*****") }}`.
 - [ ] [Fork the HCPh-fMRI-tasks repository](https://github.com/TheAxonLab/HCPh-fMRI-tasks/fork) under your user on GitHub.
 - [ ] Clone the [HCPh-fMRI-tasks repository](https://github.com/TheAxonLab/HCPh-fMRI-tasks):
     ```
@@ -109,8 +110,6 @@ This block describes how to prepare a laptop with a running *Psychopy 3* install
     ```
     git remote add upstream git@github.com:theaxonlab/HCPh-fMRI-tasks.git
     ```
-- [ ] Log on *{{ secrets.hosts.psychopy | default("███") }}* with the username *{{ secrets.login.username_psychopy| default("███") }}* and password `{{ secrets.login.password_psychopy| default("*****") }}`.
-
 - [ ] Clone the [PsychoPy repository](https://github.com/psychopy/psychopy.git):
     ```
     git clone git@github.com:psychopy/psychopy.git
@@ -129,7 +128,7 @@ This block describes how to prepare a laptop with a running *Psychopy 3* install
     ```
 - [ ] Install bdist_mpkg, py2app and attrdict:
     ```
-    pip3 attrdict py2app bdist_mpkg
+    pip3 install attrdict py2app bdist_mpkg
     ```
 - [ ] Install Psychopy using the following command:
     ```

--- a/docs/data-collection/preliminary.md
+++ b/docs/data-collection/preliminary.md
@@ -93,12 +93,83 @@ Once finalized the protocol design, it will be *frozen* and it cannot be changed
 ### Install the gas analyzer (GA)
 
 
+### Install *Psychopy* for stimuli presentation and development
+This block describes how to prepare an environment with a running *Psychopy 3* installation.
+
+- [ ] Clone the [*Psychopy* repository](https://github.com/psychopy/psychopy.git):
+    ``` shell
+    git clone git@github.com:psychopy/psychopy.git
+    ```
+- [ ] Navigate to the *Psychopy* directory:
+    ``` shell
+    cd psychopy
+    ```
+- [ ] *Psychopy* should not be installed with *Anaconda*.
+    If an anaconda environment is activated, run the following command to deactivate it:
+    ``` shell
+    conda deactivate
+    ```
+- [ ] Update pip to the latest version:
+    ``` shell
+    python3 -m pip install --upgrade pip
+    ```
+- [ ] Install bdist_mpkg, py2app and attrdict:
+    ``` shell
+    python3 -m pip install attrdict py2app bdist_mpkg
+    ```
+- [ ] Install *wxPython*.
+    ``` shell
+    python3 -m pip install -U \
+        -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-$( lsb_release -r -s ) \
+        wxPython
+    ```
+- [ ] Install *Psychopy* using the following command:
+    ``` shell
+    pip3 install -e .
+    ```
+- [ ] Try opening *Psychopy* by typing:
+    ``` shell
+    psychopy --no-splash -b
+    ```
+
+    ??? important "The first time it runs, *Psychopy* will likely request some increased permissions"
+
+        - [ ] Add a new `psychopy` group to your system.
+            ``` shell
+            sudo groupadd --force psychopy
+            ```
+        - [ ] Add your current user to the new group:
+            ``` shell
+            sudo usermod -a -G psychopy $USER
+            ```
+        - [ ] Raise security thresholds for *Psychopy*, by inserting the following into `/etc/security/limits.d/99-psychopylimits.conf`:
+            ``` text
+            @psychopy - nice -20
+            @psychopy - rtprio 50
+            @psychopy - memlock unlimited
+            ```
+
+??? bug "*Psychopy* crashes when trying to run a experiment: `pyglet.gl.ContextException: Could not create GL context`"
+
+    This is likely related to your computer having a GPU and a nonfunctional configuration:
+
+    ``` shell
+    $ glxinfo | grep PyOpenGL
+    X Error of failed request:  BadValue (integer parameter out of range for operation)
+      Major opcode of failed request:  151 (GLX)
+      Minor opcode of failed request:  24 (X_GLXCreateNewContext)
+      Value in failed request:  0x0
+      Serial number of failed request:  110
+      Current serial number in output stream:  111
+    ```
+
+    A quick attempt to solve this would be adding our user to the `video` group.
+
+    However, that is unlikely to work out so you'll need to take more actions (see [this](https://github.com/mmatl/pyrender/issues/13), and [this](https://askubuntu.com/questions/1255841/how-do-i-fix-the-glxinfo-badvalue-error-on-ubuntu-18-04))
 
 ### Preparing the *Stimuli presentation laptop* ({{ secrets.hosts.psychopy | default("███") }})
 
-This block describes how to prepare a laptop with a running *Psychopy 3* installation, the *EyeLink* software corresponding to the Eye Tracker, and finally an *Experiment synchronization service*.
-
-#### Stimuli presentation with *psychopy*
+#### Prepare the *Psychopy* experiments
 
 - [ ] Log on *{{ secrets.hosts.psychopy | default("███") }}* with the username *{{ secrets.login.username_psychopy| default("███") }}* and password `{{ secrets.login.password_psychopy| default("*****") }}`.
 - [ ] [Fork the HCPh-fMRI-tasks repository](https://github.com/TheAxonLab/HCPh-fMRI-tasks/fork) under your user on GitHub.
@@ -110,77 +181,20 @@ This block describes how to prepare a laptop with a running *Psychopy 3* install
     ```
     git remote add upstream git@github.com:theaxonlab/HCPh-fMRI-tasks.git
     ```
-- [ ] Clone the [PsychoPy repository](https://github.com/psychopy/psychopy.git):
-    ```
-    git clone git@github.com:psychopy/psychopy.git
-    ```
-- [ ] Navigate to the Psychopy directory:
-    ```
-    cd psychopy
-    ```
-- [ ] Psychopy should not be installed with anaconda. If an anaconda environment is activated, run the following command to deactivate it:
-    ```
-    conda deactivate
-    ```
-- [ ] Update pip to the latest version:
-    ```
-    pip3 install --upgrade pip
-    ```
-- [ ] Install bdist_mpkg, py2app and attrdict:
-    ```
-    pip3 install attrdict py2app bdist_mpkg
-    ```
-- [ ] Install *wxPython*.
-    ``` shell
-    pip3 install -U \
-        -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-$( lsb_release -r -s ) \
-        wxPython
-    ```
-- [ ] Install *Psychopy* using the following command:
-    ```
-    pip3 install -e .
-    ```
 - [ ] Open *Psychopy* and (optionally) a experiment file corresponding to a task by typing the following command in the terminal:
     ```
-    psychopy your_experiment.psyexp
+    psychopy {{ settings.psychopy.tasks.func_qct }}
     ```
 - [ ] For each task, check the following:
-    - [ ] {{ settings.psychopy.tasks.func_qct }} (positive-control task, QCT) :
+    - [ ] `{{ settings.psychopy.tasks.func_qct }}` (positive-control task, QCT) :
         - [ ] time it to [confirm the length](intro.md#task-timing), and
         - [ ] check the task runs properly.
-    - [ ] {{ settings.psychopy.tasks.func_rest }} (resting-state fMRI):
+    - [ ] `{{ settings.psychopy.tasks.func_rest }}` (resting-state fMRI):
         - [ ] time it to confirm the length, and
         - [ ] check that the movie is played.
-    - [ ] {{ settings.psychopy.tasks.func_bht }} (breath-holding task, BHT):
+    - [ ] `{{ settings.psychopy.tasks.func_bht }}` (breath-holding task, BHT):
         - [ ] time it to confirm the length, and
         - [ ] check the task runs properly.
-
-#### Installing *EyeLink* (eye tracker software)
-
-- [ ] Log on *{{ secrets.hosts.psychopy | default("███") }}* with the username *{{ secrets.login.username_psychopy | default("███") }}* and password `{{ secrets.login.password_psychopy | default("*****") }}`.
-
-- [ ] Enable Canonical's universe repository with the following command:
-    ```
-    sudo add-apt-repository universe
-    sudo apt update
-    ```
-- [ ] Install and update the ca-certificates package:
-    ```
-    sudo apt update
-    sudo apt install ca-certificates
-    ```
-- [ ] Add the SR Research Software Repository signing key:
-    ```
-    sudo apt-key adv --fetch-keys https://apt.sr-research.com/SRResearch_key
-    ```
-- [ ] Install the EyeLink Developers Kit:
-    ```
-    sudo apt install eyelink-display-software
-    ```
-- [ ] Install the EyeLink Data Viewer:
-    ```
-    sudo apt install eyelink-dataviewer
-    ```
 
 #### Setting up a synchronization service
 
@@ -248,6 +262,34 @@ This block describes how to prepare a laptop with a running *Psychopy 3* install
           screen /dev/ttyACM0
           ```
       - [ ] Press <span class="keypress">s</span> and verify that `^A` appears in the screen terminal.
+
+
+#### Installing *EyeLink* (eye tracker software)
+
+- [ ] Log on *{{ secrets.hosts.psychopy | default("███") }}* with the username *{{ secrets.login.username_psychopy | default("███") }}* and password `{{ secrets.login.password_psychopy | default("*****") }}`.
+
+- [ ] Enable Canonical's universe repository with the following command:
+    ```
+    sudo add-apt-repository universe
+    sudo apt update
+    ```
+- [ ] Install and update the ca-certificates package:
+    ```
+    sudo apt update
+    sudo apt install ca-certificates
+    ```
+- [ ] Add the SR Research Software Repository signing key:
+    ```
+    sudo apt-key adv --fetch-keys https://apt.sr-research.com/SRResearch_key
+    ```
+- [ ] Install the EyeLink Developers Kit:
+    ```
+    sudo apt install eyelink-display-software
+    ```
+- [ ] Install the EyeLink Data Viewer:
+    ```
+    sudo apt install eyelink-dataviewer
+    ```
 
 ## Every two months
 

--- a/docs/data-collection/preliminary.md
+++ b/docs/data-collection/preliminary.md
@@ -130,23 +130,23 @@ This block describes how to prepare a laptop with a running *Psychopy 3* install
     ```
     pip3 install attrdict py2app bdist_mpkg
     ```
-- [ ] Install wxPython. Careful to replace the ubuntu version with the one corresponding to your system (you can check which Ubuntu version is installed on your system by running `lsb_release -a` in the terminal)
-    ```
+- [ ] Install *wxPython*.
+    ``` shell
     pip3 install -U \
-        -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04 \
+        -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-$( lsb_release -r -s ) \
         wxPython
     ```
-- [ ] Install Psychopy using the following command:
+- [ ] Install *Psychopy* using the following command:
     ```
     pip3 install -e .
     ```
-- [ ] Open Psychopy, open the experiment-files corresponding to each task by typing the following command in the terminal:
+- [ ] Open *Psychopy* and (optionally) a experiment file corresponding to a task by typing the following command in the terminal:
     ```
     psychopy your_experiment.psyexp
     ```
 - [ ] For each task, check the following:
     - [ ] {{ settings.psychopy.tasks.func_qct }} (positive-control task, QCT) :
-        - [ ] time it to confirm the length, and
+        - [ ] time it to [confirm the length](intro.md#task-timing), and
         - [ ] check the task runs properly.
     - [ ] {{ settings.psychopy.tasks.func_rest }} (resting-state fMRI):
         - [ ] time it to confirm the length, and

--- a/docs/data-collection/scanning.md
+++ b/docs/data-collection/scanning.md
@@ -60,7 +60,7 @@
         Are you ready?
 
 - [ ] Wait for the participant confirmation and set the speaker off afterward.
-- [ ] Launch the `AAhead_scout_{32,64}ch-head-coil` protocol by pressing *Continue* :fontawesome-solid-play:{ .redcolor }.
+- [ ] Launch the `AAhead_scout_64ch-head-coil` protocol by pressing *Continue* :fontawesome-solid-play:{ .redcolor }.
 - [ ] Once the localizer is concluded, you can drag and drop the image stack icon (something like 🗇, with an object on the top stack) onto the image viewer. That will open the localizer on the viewer.
 
     ![drag_t1w.jpg](../assets/images/drag_t1w.jpg)
@@ -132,7 +132,7 @@
 - [ ] While the fieldmap sequence is running,
     - [ ] [Adjust the FoV](scanning-notes.md#setting-the-fov) for the positive-control-task (`func-bold_task-qct_dir-{RL,LR,PA,AP}__cmrr_me4_sms4`) fMRI sequence following the abovementioned steps, and
     - [ ] verify the *Number of measurements* with respect to the [task's timing](intro.md#task-timing) ({{ settings.mri.timings.func_qct }}).
-    - [ ] Verify that the positive-control task {{ settings.psychopy.tasks.func_qct }} is open in psychopy, that you calibrated the ET.
+    - [ ] Verify that the positive-control task `{{ settings.psychopy.tasks.func_qct }}` is open in psychopy, that you calibrated the ET.
 
 ## Acquire the functional MRI block
 - [ ] Inform the participant about the fMRI block
@@ -176,7 +176,7 @@
     - [ ] [Adjust the FoV](scanning-notes.md#setting-the-fov) for the following sequence,
     - [ ] verify the *Number of measurements* with respect to the [task's timing](intro.md#task-timing) ({{ settings.mri.timings.func_rest }}), and
     - [ ] double check that it has the setting *Magnitude et phase* selected in the drop-down menu under *Contrast>Reconstruction*.
-- [ ] Once the sequence is over, close the current experiment on psychopy and open {{ settings.psychopy.tasks.func_rest }}.
+- [ ] Once the sequence is over, close the current experiment on psychopy and open `{{ settings.psychopy.tasks.func_rest }}`.
 
 ### Resting state fMRI
 - [ ] Inform the participant:
@@ -205,7 +205,7 @@
     - [ ] [Adjust the FoV](scanning-notes.md#setting-the-fov) for the following sequence,
     - [ ] verify the *Number of measurements* with respect to the [task's timing](intro.md#task-timing) ({{ settings.mri.timings.func_bht }}), and
     - [ ] double check that it has the setting *Magnitude et phase* selected in the drop-down menu under *Contrast>Reconstruction*.
-- [ ] Once the sequence is over, close the current experiment on psychopy and open {{ settings.psychopy.tasks.func_bht }}.
+- [ ] Once the sequence is over, close the current experiment on psychopy and open `{{ settings.psychopy.tasks.func_bht }}`.
 
 ### Breath-holding task (BHT)
 - [ ] Inform the participant:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # The Human Connectome PHantom (HCPh) study: Standard Operating Procedures
 
-!!! abstract "These SOPs correspond to a Pre-registered report"
+!!! abstract "These SOPs correspond to a pre-registered report"
 
     These documents correspond to a pre-registration<sup>[1]</sup>.
     Please check the corresponding [registered report](https://osf.io/fh8mc) ([direct download](assets/files/HCPh_RR_1.4.pdf)) to get a better understanding of what these SOPs implement.

--- a/study-settings.yml
+++ b/study-settings.yml
@@ -9,10 +9,10 @@ mri:
 
 psychopy:
   tasks:
-    dwi: '`dwi.psyexp`'
-    func_rest: '`task-rest_bold.psyexp`'
-    func_bht: '`task-bht_bold.psyexp`'
-    func_qct: '`task-qct_bold.psyexp`'
+    dwi: 'dwi.psyexp'
+    func_rest: 'task-rest_bold.psyexp'
+    func_bht: 'task-bht_bold.psyexp'
+    func_qct: 'task-qct_bold.psyexp'
 
 paths:
   sourcedata: '/data/datasets/hcph-sourcedata'


### PR DESCRIPTION
fix: typos
fix: steps order
fix: missing word

enh: to make the psychopy installation successful, I first had to install wxPython separately

fix: remove the step of timing tasks before each session. I think this is not realistic especially for the resting-state that lasts 20min. Time the tasks however remains as a step in preliminary work (@acionca this has changed since you last reviewed the PR)