### PR TITLE
ENH: Describe execution of MRIQC and how to add the derivatives

### DIFF
--- a/docs/data-management/mriqc.md
+++ b/docs/data-management/mriqc.md
@@ -1,14 +1,31 @@
 
 
-## Executing MRIQC
-- [ ] Register the MRIQC container with DataLad containers-run
-- [ ] Run MRIQC:
+## Executing *MRIQC*
+!!! info "Just once, the first time you run *MRIQC* on the dataset"
+    - [ ] Register the *MRIQC* container to the dataset
+
+        ??? info "Run another version of *MRIQC*"
+            In case you want to run another version of *MRIQC*, replace `23.1.0` with the one you intend to use in the command below
+
+        ```
+        datalad containers-add --call-fmt 'singularity exec -B {{${HOME}/tmp/}} --cleanenv {img} {cmd}' mriqc --url docker://nipreps/mriqc:23.1.0
+        ```
+        We configure the containers call to automatically mount the temporary folder, because we will store the working directory there.
+
+- [ ] Run *MRIQC*:
     ```shell
+    #Assign the variable to the last session ID
+    lastsession=01
     datalad containers-run \
-        --container-name containers/mriqc \
+        --container-name mriqc \
         --input sourcedata \
-        --output . \
-        '{inputs}' '{outputs}' participant --session lastsession -w workdir
+        --output ./derivatives/mriqc-23.1.0 \
+        "{inputs} {outputs} participant --session-id ${lastsession} -w ${HOME}/tmp/hcph-dataset/mriqc-23.1.0 --mem 40G"
+    ```
+- [ ] Push the new derivatives to the remote storage.
+    ```shell
+    datalad push --to ria-storage
+    datalad push --to origin
     ```
 - [ ] Screen the T1w, DWI and BOLD visual reports, assign a quality assessment using *Q'Kay*
 - [ ] If either the dMRI or the RSfMRI quality is insufficient, schedule an extra session after the initially-planned scanning

--- a/docs/data-management/mriqc.md
+++ b/docs/data-management/mriqc.md
@@ -1,18 +1,6 @@
-
-
 ## Executing *MRIQC*
-!!! info "Just once, the first time you run *MRIQC* on the dataset"
-    - [ ] Register the *MRIQC* container to the dataset
 
-        ??? info "Run another version of *MRIQC*"
-            In case you want to run another version of *MRIQC*, replace `23.1.0` with the one you intend to use in the command below
-
-        ```
-        datalad containers-add --call-fmt 'singularity exec -B {{${HOME}/tmp/}} --cleanenv {img} {cmd}' mriqc --url docker://nipreps/mriqc:23.1.0
-        ```
-        We configure the containers call to automatically mount the temporary folder, because we will store the working directory there.
-
-- [ ] Run *MRIQC*:
+- [ ] Run *MRIQC*.
     ```shell
     #Assign the variable to the last session ID
     lastsession=01
@@ -20,13 +8,12 @@
         --container-name mriqc \
         --input sourcedata \
         --output ./derivatives/mriqc-23.1.0 \
-        "{inputs} {outputs} participant --session-id ${lastsession} -w ${HOME}/tmp/hcph-dataset/mriqc-23.1.0 --mem 40G"
+        "{inputs} {outputs} participant --session-id ${lastsession} -w ${HOME}/tmp/hcph-derivatives/mriqc-23.1.0 --mem 40G"
     ```
 - [ ] Push the new derivatives to the remote storage.
     ```shell
     datalad push --to ria-storage
     datalad push --to origin
     ```
-- [ ] Screen the T1w, DWI and BOLD visual reports, assign a quality assessment using *Q'Kay*
-- [ ] If either the dMRI or the RSfMRI quality is insufficient, schedule an extra session after the initially-planned scanning
-period to reacquire it.
+- [ ] Screen the T1w, DWI and BOLD visual reports
+- [ ] Schedule an extra session after the initially-planned scanning period to reacquire it if either the dMRI or the RSfMRI quality is insufficient.

--- a/docs/data-management/post-session.md
+++ b/docs/data-management/post-session.md
@@ -423,6 +423,9 @@ As new sessions are collected, the corresponding BIDS structures MUST be saved w
 
     !!! danger "Always double-check that data in the annex are uploaded to the RIA store"
 
-### Run MRIQC on the data and assess their quality
-Proceed with the quality assessment of the data by following the steps detailed in the [next section](./mriqc.md).
-Checking the quality of the data short after they are acquired increases the likelihood of catching systematic artifacts and reduces the risk of the latter spreading throughout the whole dataset. It also spreads the burden of visual inspection over time, avoiding to overwhelm the rater with lots of images to rate in a short time span, which in turn reduces decision fatigue.
+### Visual assessment of unprocessed data with *MRIQC*
+Checking the data quality shortly after they are acquired increases the likelihood of catching systematic artifacts early enough to avert spreading throughout the whole dataset.
+It also modulates the burden of visual inspection over time, such that we avoid overwhelming raters with outbursts of images to assess.
+Better pacing in rating throughput also contributes to reducing raters' attrition and fatigue.
+
+- [ ] Screen all the unprocessed data and assess them as described in the [next section](./mriqc.md).

--- a/docs/data-management/post-session.md
+++ b/docs/data-management/post-session.md
@@ -422,3 +422,7 @@ As new sessions are collected, the corresponding BIDS structures MUST be saved w
     ```
 
     !!! danger "Always double-check that data in the annex are uploaded to the RIA store"
+
+### Run MRIQC on the data and assess their quality
+Proceed with the quality assessment of the data by following the steps detailed in the [next section](./mriqc.md).
+Checking the quality of the data short after they are acquired increases the likelihood of catching systematic artifacts and reduces the risk of the latter spreading throughout the whole dataset. It also spreads the burden of visual inspection over time, avoiding to overwhelm the rater with lots of images to rate in a short time span, which in turn reduces decision fatigue.

--- a/docs/data-management/preliminary.md
+++ b/docs/data-management/preliminary.md
@@ -66,10 +66,11 @@ When employing high-performance computing (HPC), we provide [some specific guide
             --publish-depends ria-storage
     ```
     
-- [ ] Create a sub-dataset to host the *MRIQC* derivatives. If you will not run *MRIQC* version 23.1.0, replace the version with the one you intend to run in the command below.
+- [ ] Create a sub-dataset to host the *MRIQC* derivatives.
+    Remember to set the correct version of the container (in our case {{ settings.versions.mriqc }}).
     ``` shell
     cd /data/datasets/hcph-dataset
-    datalad create -d . derivatives/mriqc-23.1.0
+    datalad create -d . derivatives/mriqc-{{ settings.versions.mriqc }}
     ```
 
 ## *Client* side operations (when *consuming* the data)

--- a/study-settings.yml
+++ b/study-settings.yml
@@ -54,3 +54,8 @@ biopac:
   ecg_trans: 'MECMRI-2'
   pinkbox: 'MMBT-S'
   pinkbox_long: 'MMBT-S Trigger Interface Box adapter'
+
+versions:
+  mriqc: '23.1.0'
+  fmriprep: 'xxxx'
+  dmriprep: 'xxxx'


### PR DESCRIPTION
enh: add justification why QC'ing the data within two weeks of their acquisition
fix: change name of the dataset to what has been implemented (hcph -> hcph-dataset)
enh: instructions to add derivatives subdataset, run MRIQC and push to remote storage
fix: move install datalad instructions before datalad install dataset

@oesteban I'm not too sure about the way I precise the working directory to the container.
Also `mkdocs serve` does not work anymore in my computer (dependency issues of the mkdocs package), so I could not verify if the markdown renders the correct layout. If someone can check for me in the meantime that I fix my mkdocs installation --'

Mentioned in #241 