### PR TITLE
FIX: physio to BIDS conversion

### DIFF
--- a/docs/data-management/intro.md
+++ b/docs/data-management/intro.md
@@ -62,7 +62,7 @@ flowchart TB
     psychopy_pc --> |Dropbox Sync| raw_edf
     
     raw_mri -->|<i>HeudiConv</i> Script| bids_mri
-    raw_phys --->|<i>phys2bids</i> Script| bids_phys
+    raw_phys --->|<i>physio-to-bids.ipynb</i> Script| bids_phys
     raw_edf ---> |<i>edf2bids</i> Script| bids_edf
 
     bids_mri -->|FIRST Session Only !| med[Clinical Screening]

--- a/docs/data-management/post-session.md
+++ b/docs/data-management/post-session.md
@@ -147,87 +147,9 @@ To support backward compatibility (and some extra, currently unsupported feature
     chmod -R a-w $HOME/data/hcph-pilot/sub-{{ secrets.ids.pacs_subject | default("01") }}/
     ```
 
-### Generate BIDS' *events* files
-
-- [ ] Execute the script `write_event_file.py` as shown below to generate task event files.
-    This script creates JSON and TSV files containing event information and generates PNG plots for each task, displaying both physiological data and corresponding events.
-    These plots are saved in the current directory.
-    The script must be executed with the following command, where `outputdir` is the output directory of *phys2bids*:
-
-    ``` shell
-    python write_event_file.py --path ./outputdir/sub-001/ses-pilot016/func/
-    ```
-
-??? abstract "Example of a session with *events* files"
-
-    The corresponding *events* files are highlighted below:
-
-    ``` {.shell hl_lines="22-23 40-41 58-59"}
-    ses-024
-    ├── anat
-    ├── dwi
-    ├── fmap
-    ├── func
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-1_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-1_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-1_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-1_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-2_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-2_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-2_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-2_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-3_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-3_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-3_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-3_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-4_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-4_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-4_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-4_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_events.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_events.tsv
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-2_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-2_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-2_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-2_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-3_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-3_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-3_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-3_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-4_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-4_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-4_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-4_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_events.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_events.tsv
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-2_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-2_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-2_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-2_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-3_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-3_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-3_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-3_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-4_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-4_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-4_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-4_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_events.json
-    │   └── sub-001_ses-024_task-rest_dir-AP_events.tsv
-    └── sub-001_ses-024_scans.tsv
-    ```
-
 ### Convert physiological recordings into BIDS (in-house)
 
-- [ ] Install the necessary packages
+- [ ] Install the necessary packages.
     ```
     pip install bioread pandas matplotlib numpy pathlib scipy
     ```
@@ -320,6 +242,116 @@ To support backward compatibility (and some extra, currently unsupported feature
     │   ├── sub-001_ses-024_task-rest_dir-AP_recording-respiratory_physio.tsv.gz
     │   ├── sub-001_ses-024_task-rest_dir-AP_stim.json
     │   └── sub-001_ses-024_task-rest_dir-AP_stim.tsv.gz
+    └── sub-001_ses-024_scans.tsv
+    ```
+
+### Generate BIDS' *events* files
+
+- [ ] Execute the script `write_event_file.py` as shown below to generate task event files.
+    This script creates JSON and TSV files containing event information and generates PNG plots for each task, displaying both physiological data and corresponding events.
+    These plots are saved in the current directory.
+    The script must be executed with the following command, where `outputdir` is the output directory of [the conversion *Jupyter* notebook](physio-to-bids):
+
+    ``` shell
+    python write_event_file.py --path ./outputdir/sub-001/ses-pilot016/func/
+    ```
+
+??? abstract "Example of a session with *events* files"
+
+    The corresponding *events* files are highlighted below:
+
+    ``` {.shell hl_lines="42-43 66-67 90-91"}
+    ses-024
+    ├── anat
+    ├── dwi
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_dwi.bval
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_dwi.bvec
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_dwi.json
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_dwi.nii.gz
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-cardiac_physio.json
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-cardiac_physio.tsv.gz
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-respiratory_physio.json
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-respiratory_physio.tsv.gz
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_stim.json
+    │   └── sub-001_ses-024_acq-highres_dir-AP_stim.tsv.gz
+    ├── fmap
+    ├── func
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-1_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-1_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-1_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-1_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-2_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-2_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-2_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-2_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-3_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-3_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-3_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-3_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-4_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-4_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-4_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-4_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_dwi.bval
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_dwi.bvec
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_dwi.json
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_dwi.nii.gz
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-cardiac_physio.json
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-cardiac_physio.tsv.gz
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-respiratory_physio.json
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-respiratory_physio.tsv.gz
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_stim.json
+    │   └── sub-001_ses-024_acq-highres_dir-AP_stim.tsv.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_events.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_events.tsv
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-2_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-2_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-2_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-2_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-3_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-3_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-3_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-3_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-4_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-4_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-4_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-4_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_recording-cardiac_physio.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_recording-cardiac_physio.tsv.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_recording-respiratory_physio.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_recording-respiratory_physio.tsv.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_stim.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_stim.tsv.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_events.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_events.tsv
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-2_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-2_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-2_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-2_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-3_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-3_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-3_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-3_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-4_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-4_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-4_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-4_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_recording-cardiac_physio.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_recording-cardiac_physio.tsv.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_recording-respiratory_physio.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_recording-respiratory_physio.tsv.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_stim.json
+    │   └── sub-001_ses-024_task-rest_dir-AP_stim.tsv.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_events.json
+    │   └── sub-001_ses-024_task-rest_dir-AP_events.tsv
     └── sub-001_ses-024_scans.tsv
     ```
 

--- a/docs/data-management/post-session.md
+++ b/docs/data-management/post-session.md
@@ -302,7 +302,6 @@ To support backward compatibility (and some extra, currently unsupported feature
     │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-respiratory_physio.tsv.gz
     │   ├── sub-001_ses-024_acq-highres_dir-AP_stim.json
     │   └── sub-001_ses-024_acq-highres_dir-AP_stim.tsv.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_events.json
     │   ├── sub-001_ses-024_task-bht_dir-AP_events.tsv
     │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-mag_bold.json
     │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-mag_bold.nii.gz
@@ -326,7 +325,6 @@ To support backward compatibility (and some extra, currently unsupported feature
     │   ├── sub-001_ses-024_task-qct_dir-AP_recording-respiratory_physio.tsv.gz
     │   ├── sub-001_ses-024_task-qct_dir-AP_stim.json
     │   ├── sub-001_ses-024_task-qct_dir-AP_stim.tsv.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_events.json
     │   ├── sub-001_ses-024_task-qct_dir-AP_events.tsv
     │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-mag_bold.json
     │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-mag_bold.nii.gz
@@ -350,7 +348,6 @@ To support backward compatibility (and some extra, currently unsupported feature
     │   ├── sub-001_ses-024_task-rest_dir-AP_recording-respiratory_physio.tsv.gz
     │   ├── sub-001_ses-024_task-rest_dir-AP_stim.json
     │   └── sub-001_ses-024_task-rest_dir-AP_stim.tsv.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_events.json
     │   └── sub-001_ses-024_task-rest_dir-AP_events.tsv
     └── sub-001_ses-024_scans.tsv
     ```

--- a/docs/data-management/post-session.md
+++ b/docs/data-management/post-session.md
@@ -147,113 +147,12 @@ To support backward compatibility (and some extra, currently unsupported feature
     chmod -R a-w $HOME/data/hcph-pilot/sub-{{ secrets.ids.pacs_subject | default("01") }}/
     ```
 
-### Convert physiological recordings into BIDS (in-house)
-
-- [ ] Install the necessary packages.
-    ```
-    pip install bioread pandas matplotlib numpy pathlib scipy
-    ```
-- [ ] Update the appropriate session number within cell 3 in [the conversion *Jupyter* notebook](physio-to-bids).
-- [ ] Execute the notebook.
-
-??? abstract "Example of a session with physiological recordings"
-
-    The execution of the notebook on session 24 yields the following new outputs (highlighted):
-
-    ``` {.shell hl_lines="8-13 32-37 54-59 76-81"}
-    ses-024
-    ├── anat
-    ├── dwi
-    │   ├── sub-001_ses-024_acq-highres_dir-AP_dwi.bval
-    │   ├── sub-001_ses-024_acq-highres_dir-AP_dwi.bvec
-    │   ├── sub-001_ses-024_acq-highres_dir-AP_dwi.json
-    │   ├── sub-001_ses-024_acq-highres_dir-AP_dwi.nii.gz
-    │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-cardiac_physio.json
-    │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-cardiac_physio.tsv.gz
-    │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-respiratory_physio.json
-    │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-respiratory_physio.tsv.gz
-    │   ├── sub-001_ses-024_acq-highres_dir-AP_stim.json
-    │   └── sub-001_ses-024_acq-highres_dir-AP_stim.tsv.gz
-    ├── fmap
-    ├── func
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-1_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-1_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-1_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-1_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-2_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-2_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-2_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-2_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-3_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-3_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-3_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-3_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-4_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-4_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-4_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-4_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_recording-cardiac_physio.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_recording-cardiac_physio.tsv.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_recording-respiratory_physio.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_recording-respiratory_physio.tsv.gz
-    │   ├── sub-001_ses-024_task-bht_dir-AP_stim.json
-    │   ├── sub-001_ses-024_task-bht_dir-AP_stim.tsv.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-2_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-2_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-2_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-2_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-3_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-3_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-3_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-3_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-4_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-4_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-4_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-4_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_recording-cardiac_physio.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_recording-cardiac_physio.tsv.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_recording-respiratory_physio.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_recording-respiratory_physio.tsv.gz
-    │   ├── sub-001_ses-024_task-qct_dir-AP_stim.json
-    │   ├── sub-001_ses-024_task-qct_dir-AP_stim.tsv.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-2_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-2_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-2_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-2_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-3_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-3_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-3_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-3_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-4_part-mag_bold.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-4_part-mag_bold.nii.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-4_part-phase_bold.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-4_part-phase_bold.nii.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_recording-cardiac_physio.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_recording-cardiac_physio.tsv.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_recording-respiratory_physio.json
-    │   ├── sub-001_ses-024_task-rest_dir-AP_recording-respiratory_physio.tsv.gz
-    │   ├── sub-001_ses-024_task-rest_dir-AP_stim.json
-    │   └── sub-001_ses-024_task-rest_dir-AP_stim.tsv.gz
-    └── sub-001_ses-024_scans.tsv
-    ```
-
 ### Generate BIDS' *events* files
 
-- [ ] Execute the script `write_event_file.py` as shown below to generate task event files.
-    This script creates JSON and TSV files containing event information and generates PNG plots for each task, displaying both physiological data and corresponding events.
-    These plots are saved in the current directory.
-    The script must be executed with the following command, where `outputdir` is the output directory of [the conversion *Jupyter* notebook](physio-to-bids):
+- [ ] Execute conversion with `code/events/psychopy2events`:
 
     ``` shell
-    python write_event_file.py --path ./outputdir/sub-001/ses-pilot016/func/
+    python psychopy2events.py --path ./outputdir/sub-001/ses-pilot016/func/
     ```
 
 ??? abstract "Example of a session with *events* files"
@@ -349,6 +248,105 @@ To support backward compatibility (and some extra, currently unsupported feature
     │   ├── sub-001_ses-024_task-rest_dir-AP_stim.json
     │   └── sub-001_ses-024_task-rest_dir-AP_stim.tsv.gz
     │   └── sub-001_ses-024_task-rest_dir-AP_events.tsv
+    └── sub-001_ses-024_scans.tsv
+    ```
+
+### Convert physiological recordings into BIDS (in-house)
+
+- [ ] Install the necessary packages.
+    ```
+    python -m pip install bioread pandas matplotlib numpy pathlib scipy
+    ```
+
+- [ ] Update the appropriate session number within cell 3 in [the conversion *Jupyter* notebook](physio-to-bids).
+- [ ] Execute the notebook.
+
+??? abstract "Example of a session with physiological recordings"
+
+    The execution of the notebook on session 24 yields the following new outputs (highlighted):
+
+    ``` {.shell hl_lines="8-13 32-37 54-59 76-81"}
+    ses-024
+    ├── anat
+    ├── dwi
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_dwi.bval
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_dwi.bvec
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_dwi.json
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_dwi.nii.gz
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-cardiac_physio.json
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-cardiac_physio.tsv.gz
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-respiratory_physio.json
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_recording-respiratory_physio.tsv.gz
+    │   ├── sub-001_ses-024_acq-highres_dir-AP_stim.json
+    │   └── sub-001_ses-024_acq-highres_dir-AP_stim.tsv.gz
+    ├── fmap
+    ├── func
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-1_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-1_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-1_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-1_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-2_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-2_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-2_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-2_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-3_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-3_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-3_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-3_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-4_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-4_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-4_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_echo-4_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_recording-cardiac_physio.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_recording-cardiac_physio.tsv.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_recording-respiratory_physio.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_recording-respiratory_physio.tsv.gz
+    │   ├── sub-001_ses-024_task-bht_dir-AP_stim.json
+    │   ├── sub-001_ses-024_task-bht_dir-AP_stim.tsv.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-1_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-2_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-2_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-2_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-2_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-3_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-3_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-3_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-3_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-4_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-4_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-4_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_echo-4_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_recording-cardiac_physio.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_recording-cardiac_physio.tsv.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_recording-respiratory_physio.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_recording-respiratory_physio.tsv.gz
+    │   ├── sub-001_ses-024_task-qct_dir-AP_stim.json
+    │   ├── sub-001_ses-024_task-qct_dir-AP_stim.tsv.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-1_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-2_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-2_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-2_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-2_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-3_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-3_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-3_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-3_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-4_part-mag_bold.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-4_part-mag_bold.nii.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-4_part-phase_bold.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_echo-4_part-phase_bold.nii.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_recording-cardiac_physio.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_recording-cardiac_physio.tsv.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_recording-respiratory_physio.json
+    │   ├── sub-001_ses-024_task-rest_dir-AP_recording-respiratory_physio.tsv.gz
+    │   ├── sub-001_ses-024_task-rest_dir-AP_stim.json
+    │   └── sub-001_ses-024_task-rest_dir-AP_stim.tsv.gz
     └── sub-001_ses-024_scans.tsv
     ```
 

--- a/docs/data-management/post-session.md
+++ b/docs/data-management/post-session.md
@@ -227,6 +227,10 @@ To support backward compatibility (and some extra, currently unsupported feature
 
 ### Convert physiological recordings into BIDS (in-house)
 
+- [ ] Install the necessary packages
+    ```
+    pip install bioread pandas matplotlib numpy pathlib scipy
+    ```
 - [ ] Update the appropriate session number within cell 3 in [the conversion *Jupyter* notebook](physio-to-bids).
 - [ ] Execute the notebook.
 


### PR DESCRIPTION
enh: you have to install bioread before being able to run the notebook

PS I tried to install bioread with `conda install -c auto bioread` and it lead me in a loophole of dependency issues, because that one required python 2.7, but other packages needed for this notebook need python 3.2. Anyway, bioread 3.0.1 need to be installed and with pip install it takes automatically that version.
Should we mention sth about this in the SOP?


fix: we are not using *phys2bids* for BIDS conversion of physio, but our in-house *physio-to-bids.ipynb*
fix: reverse order of physio BIDS conversion and event generation
fix: accordingly, modify the example of a session containing `events.tsv` (it contains both `physio.tsv.gz` and `events.tsv`)
fix: delete `events.json` from example of a session, because those will be stored higher in the dataset (and only one per task instead of one json per tsv)

Closes #399 