### PR TITLE
ENH: Add `events.tsv` to the post-scanner flowchart

### DIFF
--- a/docs/data-management/intro.md
+++ b/docs/data-management/intro.md
@@ -67,7 +67,7 @@ flowchart TB
     raw_mri -->|<i>HeudiConv</i> Script| bids_mri
     raw_phys --->|<i>physio-to-bids.ipynb</i> Script| bids_phys
     raw_edf ---> |<i>edf2bids</i> Script| bids_edf
-    raw_events ---> |<i>write_event_file.py</i> Script| bids_events
+    raw_events ---> |<i>psychopy2events.py</i> Script| bids_events
 
     bids_mri -->|FIRST Session Only !| med[Clinical Screening]
     med -->|"Incidental(s)"| alert[Alert Participant]
@@ -124,4 +124,7 @@ The above graph can be detailed into two main data workflows:
 1. **MRI data**.
     Stored on the CHUV PACS, the raw MRI data should first be locally [converted to BIDS](post-session.md/#convert-imaging-data-to-bids-with-heudiconv). Then both the raw and BIDS compliant data are to be synchronized with the [*Datalad* dataset](preliminary.md/#adding-data-or-metadata). From there, the BIDS compliant data can be [quality controlled](./mriqc.md) and [pre-processed](../processing/preprocessing.md) using the corresponding packages (e.g. *MRIQC*, *fMRIPrep*, *dMRIPrep*) to allow computation of analysis-grade derivatives (e.g. [functional](../processing/functional-connectivity.md) or structural connectivity).
 2. **Physiological data**.
-    Physiological data stored in the *stimuli presentation laptop* ({{ secrets.hosts.psychopy | default("███") }}) and the *physio-recording Laptop* ({{ secrets.hosts.acqknowledge | default("███") }}) are synchronized with a cloud storage using *Dropbox*. The *AcqKnowledge* and ET physiological data are converted to BIDS using [*phys2bids*](physio-to-bids.ipynb) and *etf2bids* respectively. The logs from *psychopy* are converted into BIDS `_events.tsv` files using the [*write_event_file.py*](./post-session.md/#generate-bids-events-files) script. **Further processing steps such as denoising should be defined soon.**
+    Physiological data stored in the *stimuli presentation laptop* ({{ secrets.hosts.psychopy | default("███") }}) and the *physio-recording laptop* ({{ secrets.hosts.acqknowledge | default("███") }}) are synchronized with a cloud storage using *Dropbox*.
+    The physiological signals (*AcqKnowledge*) and ET's recordings are converted to BIDS using [*phys2bids*](physio-to-bids.ipynb) and *etf2bids*, respectively.
+    The logs from *Psychopy* are converted into BIDS' *events* files with the [*psychopy2events.py*](./post-session.md/#generate-bids-events-files) script.
+    **Further processing steps, such as denoising, should be defined soon.**

--- a/docs/data-management/intro.md
+++ b/docs/data-management/intro.md
@@ -23,18 +23,20 @@ flowchart TB
         bids_mri[BIDS MRI]
         bids_phys[BIDS Physio]
         bids_edf[BIDS edf]
+        bids_events[BIDS Events]
     end
 
     subgraph dropbox[<b>Dropbox</b>]
         raw_phys[Raw Physio]
         raw_edf[Raw edf]
+        raw_events[<i>Psychopy</i> Logs]
     end
     
     subgraph datalad[<b>DataLad</b>]
         bids_mri_datalad[BIDS MRI]
         bids_phys_datalad[BIDS Physio]
         bids_edf_datalad[BIDS edf]
-        %%bids_phys_datalad[BIDS Physio]
+        bids_events_datalad[BIDS Events]
 
         mriqc_out[Visual reports]
         preproc_fMRI[Preprocessed fMRI]
@@ -60,15 +62,18 @@ flowchart TB
     physio -->|Dropbox Sync| raw_phys
     et_pc -->|Psychopy| psychopy_pc
     psychopy_pc --> |Dropbox Sync| raw_edf
+    psychopy_pc --> |Dropbox Sync| raw_events
     
     raw_mri -->|<i>HeudiConv</i> Script| bids_mri
     raw_phys --->|<i>physio-to-bids.ipynb</i> Script| bids_phys
     raw_edf ---> |<i>edf2bids</i> Script| bids_edf
+    raw_events ---> |<i>write_event_file.py</i> Script| bids_events
 
     bids_mri -->|FIRST Session Only !| med[Clinical Screening]
     med -->|"Incidental(s)"| alert[Alert Participant]
     class alert imp
 
+    local_data --->|<i>datalad save</i>| datalad
     local_data --->|<i>cron</i> Job| HOrUs
     HOrUs ---> datalad
     bids_mri_datalad -->|MRIQC| mriqc_out[Visual Reports]
@@ -119,4 +124,4 @@ The above graph can be detailed into two main data workflows:
 1. **MRI data**.
     Stored on the CHUV PACS, the raw MRI data should first be locally [converted to BIDS](post-session.md/#convert-imaging-data-to-bids-with-heudiconv). Then both the raw and BIDS compliant data are to be synchronized with the [*Datalad* dataset](preliminary.md/#adding-data-or-metadata). From there, the BIDS compliant data can be [quality controlled](./mriqc.md) and [pre-processed](../processing/preprocessing.md) using the corresponding packages (e.g. *MRIQC*, *fMRIPrep*, *dMRIPrep*) to allow computation of analysis-grade derivatives (e.g. [functional](../processing/functional-connectivity.md) or structural connectivity).
 2. **Physiological data**.
-    Physiological data stored in the *stimuli presentation laptop* ({{ secrets.hosts.psychopy | default("███") }}) and the *physio-recording Laptop* ({{ secrets.hosts.acqknowledge | default("███") }}) are synchronized with a cloud storage using *Dropbox*. The *AcqKnowledge* and ET physiological data are converted to BIDS using [*phys2bids*](physio-to-bids.ipynb) and *etf2bids* respectively. **Further processing steps such as denoising should be defined soon.**
+    Physiological data stored in the *stimuli presentation laptop* ({{ secrets.hosts.psychopy | default("███") }}) and the *physio-recording Laptop* ({{ secrets.hosts.acqknowledge | default("███") }}) are synchronized with a cloud storage using *Dropbox*. The *AcqKnowledge* and ET physiological data are converted to BIDS using [*phys2bids*](physio-to-bids.ipynb) and *etf2bids* respectively. The logs from *psychopy* are converted into BIDS `_events.tsv` files using the [*write_event_file.py*](./post-session.md/#generate-bids-events-files) script. **Further processing steps such as denoising should be defined soon.**


### PR DESCRIPTION
- Add flowchart links from *psychopy* computer (psychopy logs) to the BIDS `events.tsv` files
- Add additional link between local storage and *datalad*
- Update description with a link to the events computation (probably to be updated)

closes #398 