### PR TITLE
ENH: Add *PyBIDS*' indexing and address BIDS-Validator errors

### DIFF
--- a/docs/data-management/mriqc.md
+++ b/docs/data-management/mriqc.md
@@ -19,7 +19,7 @@
         --container-name mriqc \
         --input sourcedata \
         --output ./derivatives/mriqc-23.1.0 \
-        "{inputs} {outputs} participant --session-id ${lastsession} -w ${HOME}/tmp/hcph-derivatives/mriqc-23.1.0 --mem 40G"
+        "{inputs} {outputs} participant --session-id ${lastsession} -w ${HOME}/tmp/hcph-derivatives/mriqc-23.1.0 --mem 40G --bids-database-dir {{ settings.paths.hcph_bids }}/.bids-index"
     ```
 
 - [ ] Check that *MRIQC* generated all expected individual reports.

--- a/docs/data-management/mriqc.md
+++ b/docs/data-management/mriqc.md
@@ -132,11 +132,11 @@ In addition, *MRIQC* is executed prior any further processing step considering o
 
 ### Assessing anatomical images
 - [ ] Open the *MRIQC* group report on a current Web Browser (*Google Chrome* is preferred).
-- [ ] Visualize the IQMs distributions and apply the [exclusion critera](qaqc-criteria.md#group-report).
+- [ ] Visualize the IQMs distributions and apply the [exclusion criteria](qaqc-criteria.md#group-report).
 
 ### Assessing functional images
 - [ ] Open the *MRIQC* group report on a current Web Browser (*Google Chrome* is preferred).
-- [ ] Visualize the IQMs distributions and apply the [exclusion critera](qaqc-criteria.md#group-report-1).
+- [ ] Visualize the IQMs distributions and apply the [exclusion criteria](qaqc-criteria.md#group-report-1).
 
 
 [1]: https://doi.org/10.3389/fnimg.2022.1073734 "Provins, C., … Esteban, O. (2023). Quality Control in functional MRI studies with MRIQC and fMRIPrep. Frontiers in Neuroimaging 1:1073734. doi:10.3389/fnimg.2022.1073734 (OA)."

--- a/docs/data-management/qaqc-criteria.md
+++ b/docs/data-management/qaqc-criteria.md
@@ -87,7 +87,7 @@ For accurate estimation of task activation, it is essential to check the quality
 
       Exclude the session if any of these ghosts overlap cortical gray matter.
 
-- [ ] Check for high-standard-deviation vertical strikes in the saggital plane of the standard deviation map.
+- [ ] Check for high-standard-deviation vertical strikes in the sagittal plane of the standard deviation map.
 
 #### Carpetplot and nuisance signals
 
@@ -133,7 +133,7 @@ For accurate estimation of task activation, it is essential to check the quality
 
       Exclude the session if any of these ghosts overlap cortical gray matter.
 
-- [ ] Check for high standard deviation vertical strikes in the saggital plane of the standard deviation map.
+- [ ] Check for high standard deviation vertical strikes in the sagittal plane of the standard deviation map.
 
 - [ ] Check for low SNR characterized by a grainy picture. This dataset is specifically subject to this artifact, because we used multiband acceleration.
 

--- a/include/abbreviations.md
+++ b/include/abbreviations.md
@@ -1,5 +1,6 @@
 *[AP]: anterior-to-posterior
 *[BHT]: breath-holding task
+*[BEP]: BIDS Extension Proposal
 *[BIDS]: Brain Imaging Data Structure
 *[BNC]: a radio-frequency coaxial connector (initialism of 'Bayonet Neill–Concelman')
 *[BOLD]: blood-oxygen-level dependent

--- a/study-settings.yml
+++ b/study-settings.yml
@@ -21,6 +21,7 @@ psychopy:
 paths:
   sourcedata: '/data/datasets/hcph-sourcedata'
   pilot_sourcedata: '/data/datasets/hcph-pilot-sourcedata'
+  hcph_bids: '/data/datasets/hcph-dataset'
 
 eyetracker:
   vendor: 'SR Research Ltd.'


### PR DESCRIPTION
This PR introduces how to update *PyBIDS*' database file. Using this file, the runtime of our tools is dramatically reduced (esp. because it also contains the metadata index).

This PR also improves the rendering of the BIDS validator output.

FYI @celprov @acionca (this relates to the PE direction problem)