### PR TITLE
FIX: PyBIDS MUST be called with ``--index-metadata``

### DIFF
--- a/docs/data-management/post-session.md
+++ b/docs/data-management/post-session.md
@@ -626,7 +626,7 @@ Better pacing in rating throughput also contributes to reducing raters' attritio
 - [ ] Reset the database file:
 
     ``` shell
-    $( dirname $( which python ) )/pybids layout --reset-db --no-validate . .bids-index/
+    $( dirname $( which python ) )/pybids layout --reset-db --no-validate --index-metadata . .bids-index/
     ```
 
     Successful execution will finalize with a message: `Successfully generated database index at {{ settings.paths.hcph_bids }}/.bids-index`.


### PR DESCRIPTION
Otherwise, we'll get the missing `PhaseEncodingDirection` errors and others.