### PR TITLE
FIX: QA/QC of denoising not implemented

### DIFF
--- a/docs/data-management/qaqc-general.md
+++ b/docs/data-management/qaqc-general.md
@@ -1,7 +1,7 @@
 # General QA/QC protocol
 
 Following our protocols<sup>[1]</sup> and best practices<sup>[2]</sup>, we establish quality checkpoints after the outstanding stages of our neuroimaging pipeline.
-That is, we establish a checkpoint on the [unprocessed (before preprocessing) data](mriqc.md#visualizing-mriqcs-individual-reports), on the [preprocessed data](../processing/preprocessing.md#visualizing-fmripreps-individual-reports), and further downstream analysis points such as [denoising and temporal filtering](../processing/functional-connectivity#qaqc-of-denoised-data) or the [extracted FC](../processing/qaqc-criteria-FC.md).
+That is, we establish a checkpoint on the [unprocessed (before preprocessing) data](mriqc.md#visualizing-mriqcs-individual-reports), on the [preprocessed data](../processing/preprocessing.md#visualizing-fmripreps-individual-reports), and further downstream analysis points such as the [extracted FC](../processing/qaqc-criteria-FC.md).
 
 !!! danger "Immediately report errors or quality issues encountered"
 

--- a/docs/data-management/qaqc-general.md
+++ b/docs/data-management/qaqc-general.md
@@ -1,7 +1,7 @@
 # General QA/QC protocol
 
 Following our protocols<sup>[1]</sup> and best practices<sup>[2]</sup>, we establish quality checkpoints after the outstanding stages of our neuroimaging pipeline.
-That is, we establish a checkpoint on the [unprocessed (before preprocessing) data](mriqc.md#visualizing-mriqcs-individual-reports), on the [preprocessed data](../processing/preprocessing.md#visualizing-fmripreps-individual-reports), and further downstream analysis points such as the [extracted FC](../processing/qaqc-criteria-FC.md).
+That is, we establish a checkpoint [after the conversion to BIDS](post-session.md#formal-qc), on the [unprocessed (before preprocessing) data](mriqc.md#visualizing-mriqcs-individual-reports), on the [preprocessed data](../processing/preprocessing.md#visualizing-fmripreps-individual-reports), and further downstream analysis points such as the [extracted FC](../processing/qaqc-criteria-FC.md).
 
 !!! danger "Immediately report errors or quality issues encountered"
 

--- a/docs/data-management/qaqc-general.md
+++ b/docs/data-management/qaqc-general.md
@@ -1,7 +1,7 @@
 # General QA/QC protocol
 
 Following our protocols<sup>[1]</sup> and best practices<sup>[2]</sup>, we establish quality checkpoints after the outstanding stages of our neuroimaging pipeline.
-That is, we establish a checkpoint [after the conversion to BIDS](post-session.md#formal-qc), on the [unprocessed (before preprocessing) data](mriqc.md#visualizing-mriqcs-individual-reports), on the [preprocessed data](../processing/preprocessing.md#visualizing-fmripreps-individual-reports), and further downstream analysis points such as the [extracted FC](../processing/qaqc-criteria-FC.md).
+That is, we establish checkpoints [after the conversion to BIDS](post-session.md#formal-qc), on the [unprocessed (before preprocessing) data](mriqc.md#visualizing-mriqcs-individual-reports), on the [preprocessed data](../processing/preprocessing.md#visualizing-fmripreps-individual-reports), and further downstream, for instance, following [FC extraction](../processing/qaqc-criteria-FC.md).
 
 !!! danger "Immediately report errors or quality issues encountered"
 

--- a/docs/processing/functional-connectivity.md
+++ b/docs/processing/functional-connectivity.md
@@ -67,7 +67,7 @@ In the end, the data structure will look like this:
 │                   └── func
 ```
 
-## QA/QC of denoised data
+## QA/QC of FC
 
 - [ ] Navigate to the `figures/` folder where the visual reports were saved.
     Following the above data structure, it would be the folder:

--- a/docs/processing/qaqc-criteria-FC.md
+++ b/docs/processing/qaqc-criteria-FC.md
@@ -1,4 +1,4 @@
-# QA criteria for denoised data
+# QA criteria for FC
 
 !!! warning "Contradictory QA counter-measures"
     In the following two subsections, the suggested counter-measures when QA criteria are not met propose changing the cut-off frequency of the low-pass filter in opposed directions, and therefore, *solutions compete*.
@@ -47,7 +47,7 @@ Now we will assess that QC-FC distribution<sup>[2]</sup> and the null distributi
     - [ ] Include more motion regressors by switching motion regression strategy using the `--motion "full"` flag when running `funconn.py`.
     - [ ] If tweaking the preprocessing does not suffice, revise [the exclusion criteria by excluding additional sessions](qaqc-criteria-FC.md#qc-fc-versus-euclidean-distance-1).
 
-# Exclusion criteria for denoised data
+# Exclusion criteria for FC
 
 ## FC distributions
 


### PR DESCRIPTION
As explained in #384, we finally did not implement QA/QC of the denoising.

We also implement a formal QC checkpoint, as such I've added it to the overview.

fix: change the title of the section as the QA/QC is for FC not denoising
fix: in the overview, delete mention of a QC for denoising
fix: add formal qc in qc overview