### PR TITLE
FIX: small fixes in the QC of unprocessed data section

### DIFF
--- a/docs/data-management/mriqc.md
+++ b/docs/data-management/mriqc.md
@@ -109,7 +109,7 @@ If there are, follow the procedure described in ["*MRIQC* failed to produce all 
         We employ the QCT (mainly) and the BHT as proxies for the quality of the RSfMRI run.
         Screening the reports in the prescribed order (QCT — BHT — RSfMRI) helps identify issues in the QCT and BHT that may anticipate problems in the RSfMRI.
 
-- [ ] Visualize all echo-wise visualizations of the base report following those four steps:
+- [ ] Screen all echo-wise visualizations of the base report following these four steps:
     - [ ] Visualize the first mosaic (standard-deviation) and apply the corresponding [exclusion criteria](qaqc-criteria-unprocessed.md#standard-deviation-of-signal-through-time)
     - [ ] Proceed to the background view and search for [artifacts](qaqc-criteria-unprocessed.md#view-of-the-background-of-the-voxel-wise-average-of-the-bold-timeseries).
     - [ ] Inspect the zoomed-in view of the average BOLD mosaic and apply the same [exclusion criteria](qaqc-criteria-unprocessed.md#average-signal-through-time).    

--- a/docs/data-management/mriqc.md
+++ b/docs/data-management/mriqc.md
@@ -65,7 +65,7 @@ Following our protocols<sup>[1]</sup>, the quality of unprocessed images MUST be
 In addition, *MRIQC* is executed prior any further processing step considering our preliminary findings regarding *defacing*<sup>[2]</sup>.
 
 ### Assessing anatomical images (T<sub>1</sub>-weighted and T<sub>2</sub>-weighted)
-- [ ] Open each *MRIQC* report on a current Web Browser (*Google Chrome* is preferred).
+- [ ] Open each *MRIQC* report on a Web Browser.
 - [ ] Check that the visual report is complete when you open it.
 
     ??? bug "A visual report is incomplete"
@@ -98,7 +98,7 @@ If there are, follow the procedure described in ["*MRIQC* failed to produce all 
     - [ ] Immediately report RSfMRI images deemed *exclude* as an issue in [the dataset's repository](https://github.com/{{ secrets.data.gh_repo | default('<organization>/<repo_name>') }}/issues).
     - [ ] Proceed to [scheduling an extra session](../recruitment-scheduling-screening/scheduling.md) after the initially-planned scanning period.
 
-- [ ] Open each *MRIQC* report on a current web browser (*Google Chrome* is preferred) in the following order:
+- [ ] Open each *MRIQC* report on a Web Browser in the following order:
 
     1. QCT,
     1. BHT, and
@@ -109,22 +109,21 @@ If there are, follow the procedure described in ["*MRIQC* failed to produce all 
         We employ the QCT (mainly) and the BHT as proxies for the quality of the RSfMRI run.
         Screening the reports in the prescribed order (QCT — BHT — RSfMRI) helps identify issues in the QCT and BHT that may anticipate problems in the RSfMRI.
 
-- [ ] Visualize all echo-wise visualizations of the base report following those two steps:
-    - [ ] Visualize the first mosaic (standard-deviation) and apply the corresponding [exclusion criteria](qaqc-criteria-unprocessed.md#functional-mri)    
-    - [ ] Scroll down to the carpet plot and apply the corresponding [exclusion criteria](qaqc-criteria-unprocessed.md#functional-mri).
-- [ ] Inspect the background view and search for [artifacts](qaqc-criteria-unprocessed.md#functional-mri) in the "Extended echo-wise reports" section.
-- [ ] Scroll down to the average BOLD mosaic and apply the corresponding [exclusion criteria](qaqc-criteria-unprocessed.md#functional-mri).
-- [ ] Inspect the zoomed-in view of the average BOLD mosaic as well and apply the same [exclusion criteria](qaqc-criteria-unprocessed.md#functional-mri).
+- [ ] Visualize all echo-wise visualizations of the base report following those four steps:
+    - [ ] Visualize the first mosaic (standard-deviation) and apply the corresponding [exclusion criteria](qaqc-criteria-unprocessed.md#standard-deviation-of-signal-through-time)
+    - [ ] Proceed to the background view and search for [artifacts](qaqc-criteria-unprocessed.md#view-of-the-background-of-the-voxel-wise-average-of-the-bold-timeseries).
+    - [ ] Inspect the zoomed-in view of the average BOLD mosaic and apply the same [exclusion criteria](qaqc-criteria-unprocessed.md#average-signal-through-time).    
+    - [ ] Scroll down to the carpet plot and apply the corresponding [exclusion criteria](qaqc-criteria-unprocessed.md#carpetplot-and-nuisance-signals).
+
+- [ ] Inspect the average BOLD mosaic for each echo in the "Extended echo-wise reports" section and apply the corresponding [exclusion criteria](qaqc-criteria-unprocessed.md#average-signal-through-time).
+
+- [ ] Proceed as [earlier](#mriqc-failed) if errors are reported within the "Errors" section.
 
 ## Visualizing *MRIQC*'s group reports
 
-### Assessing anatomical images
-- [ ] Open the *MRIQC* group report on a current Web Browser (*Google Chrome* is preferred).
-- [ ] Visualize the IQM distributions and apply the [exclusion criteria](qaqc-criteria-unprocessed.md#group-report).
-
-### Assessing functional images
-- [ ] Open the *MRIQC* group report on a current Web Browser (*Google Chrome* is preferred).
-- [ ] Visualize the IQM distributions and apply the [exclusion criteria](qaqc-criteria-unprocessed.md#group-report-1).
+Visualize the group report for each modality in the following order: anatomical, functional and diffusion.
+- [ ] Open the *MRIQC* group report on a Web Browser.
+- [ ] Visualize the IQM distributions and apply the [exclusion criteria](qaqc-criteria-unprocessed.md#group-report) corresponding to the modality.
 
 
 [1]: https://doi.org/10.3389/fnimg.2022.1073734 "Provins, C., … Esteban, O. (2023). Quality Control in functional MRI studies with MRIQC and fMRIPrep. Frontiers in Neuroimaging 1:1073734. doi:10.3389/fnimg.2022.1073734 (OA)."

--- a/docs/data-management/qaqc-criteria-unprocessed.md
+++ b/docs/data-management/qaqc-criteria-unprocessed.md
@@ -100,6 +100,7 @@ As such, verifying that the subjects were attempting to perform the instructed t
       - [ ] Ghosts caused by external elements such as headsets or mirror frames.
       Exclude the session if any of these ghosts overlap cortical gray matter.
 - [ ] Check for high-standard-deviation vertical strikes in the sagittal plane of the standard deviation map.
+    Exclude the session if the vertical strike continuously traverse more than half of the brain's length.
 
 #### Carpetplot and nuisance signals
 
@@ -120,7 +121,7 @@ As such, verifying that the subjects were attempting to perform the instructed t
 
 #### View of the background of the voxel-wise average of the BOLD timeseries
 
-- [ ] Check for ghosts within the brain:
+- [ ] Check for ghosts:
       - [ ] Overlapping wrap-around.
       - [ ] Ghosts caused by external elements such as headsets or mirror frames.
       Exclude the session if any of these ghosts overlap cortical gray matter.

--- a/docs/data-management/qaqc-general.md
+++ b/docs/data-management/qaqc-general.md
@@ -14,6 +14,7 @@ As we previously emphasize in our protocol<sup>[1]</sup>, QC exclusion criteria 
 Following the *NiPreps* guidelines and best practices, quality checkpoints are implemented with visual reports that are released alongside the data and analyses.
 These visual reports contain several *atomic views* (meaning, a single quality facet of the data or a particular processing step), which we call *reportlets*, that together allow the curator assess the quality.
 These visual reports are formatted as HTML documents, and therefore they are presented *linearly*.
+*Google Chrome* is the preferred Web Browser to open the HTML reports.
 The following admonition will be found at several places of this protocol to suggest that *visual reports* can be navigated freely to ensure all aspects of quality have been properly assessed:
 
 !!! tip "It is RECOMMENDED to jump back and forth through sections while screening the visual report."

--- a/docs/processing/preprocessing.md
+++ b/docs/processing/preprocessing.md
@@ -53,7 +53,7 @@ If some derivatives are missing, it is a sign that *fMRIPrep* encountered an err
 
 ### Anatomical preprocessing assessment
 
-- [ ] Open the *fMRIPrep* anatomical report on a current Web Browser (*Google Chrome* is preferred).
+- [ ] Open the *fMRIPrep* anatomical report on a Web Browser.
 - [ ] Assess the "Summary" section and apply the [QA/QC criteria](qaqc-criteria-preprocessed.md#summary).
 - [ ] Assess the "Anatomical conformation" section and apply the [QA/QC criteria](qaqc-criteria-preprocessed.md#anatomical-conformation).
 - [ ] Assess the mosaic showing the calculated brain mask and brain tissue segmentation, and apply the [QA/QC criteria](qaqc-criteria-preprocessed.md#brain-mask-and-brain-tissue-segmentation-of-the-t1w).
@@ -64,7 +64,7 @@ If some derivatives are missing, it is a sign that *fMRIPrep* encountered an err
 
 ### Assessment of fMRI Preprocessing
 
-- [ ] Open each *fMRIPrep* functional report on a current Web Browser (*Google Chrome* is preferred).
+- [ ] Open each *fMRIPrep* functional report on a Web Browser.
 - [ ] Go through the section of each fMRI run and proceed as follows:
 
     ??? important "IMPORTANT — QCT and BHT are assessed first as proxies for the RSfMRI run's quality."


### PR DESCRIPTION
fix: move information about google chrome being the preferred web browser under QA/QC general to avoid repetition
fix: avoid repetition of how to visualize MRIQC group report 
fix: define exclusion criteria in case of high std vertical strike
fix: rectify order of reportlets in multi-echo fMRI report