### PR TITLE
FIX: Update *mkdocs-jupyter* plugin pin (to 0.24.7+)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 codespell
 markdown-include
 mkdocs
-mkdocs-jupyter==0.24.2
+mkdocs-jupyter~=0.24.7
 mkdocs-macros-plugin
 mkdocs-material>=9.4
 git-changelog


### PR DESCRIPTION
Resolves the error we hit when building with recent versions of mkdocs:

```
File "/usr/local/lib/python3.10/site-packages/mkdocs_jupyter/plugin.py",
line 9, in <module>
    from mkdocs.tests.base import get_markdown_toc
ModuleNotFoundError: No module named 'mkdocs.tests'
```