### PR TITLE
FIX: rectify details about opening the mood questionnaires

### DIFF
--- a/docs/data-collection/tear-down.md
+++ b/docs/data-collection/tear-down.md
@@ -32,7 +32,13 @@
 - [ ] Help the participant step down and accompany them out to the control room.
 - [ ] Help the participant recover their personal belongings and change clothes if necessary.
 - [ ] Solicit more feedback on participant's comfort for future sessions.
-- [ ] Ask the participant to fill out the `After scan` part of the covariates collection on the issue you opened [earlier](pre-session.md#collection-of-covariates).
+- [ ] Collect `After scan` covariates
+    - [ ] Click [this link](https://github.com/{{ secrets.data.covariates_repo | default('<gh_user>/<name>') }}/issues/new?assignees=acionca&labels=mood%2Cafter&projects=&template=mood-questionnaire-after.yml&title=%5BMOOD%5D%5BAFTER%5D+sub-001_ses-yyy), or alternatively
+    - [ ] manually open a GitHub Issue at the [questionnaire repository](https://github.com/{{ secrets.data.covariates_repo | default('<gh_user>/<name>') }}):
+        - [ ] Under the section `Issues`, click on <span class="consolebutton green">New issue</span>
+        - [ ] Select the `Mood questionnaire after scan` template by clicking on <span class="consolebutton green">Get started</span>
+    - [ ] Fill in the session id (accessible in the [schedule](participant-prep.md/#session-schedule-reliability))
+    - [ ] Ask the participant to fill the rest of the form
 - [ ] Solicit tickets and receipts for transportation.
 - [ ] Give the participant the corresponding compensation for the participation and transportation.
 - [ ] Ask the participant to sign the receipt of the amount of the financial compensation.

--- a/docs/data-collection/tear-down.md
+++ b/docs/data-collection/tear-down.md
@@ -32,13 +32,14 @@
 - [ ] Help the participant step down and accompany them out to the control room.
 - [ ] Help the participant recover their personal belongings and change clothes if necessary.
 - [ ] Solicit more feedback on participant's comfort for future sessions.
-- [ ] Collect `After scan` covariates
-    - [ ] Click [this link](https://github.com/{{ secrets.data.covariates_repo | default('<gh_user>/<name>') }}/issues/new?assignees=acionca&labels=mood%2Cafter&projects=&template=mood-questionnaire-after.yml&title=%5BMOOD%5D%5BAFTER%5D+sub-001_ses-yyy), or alternatively
-    - [ ] manually open a GitHub Issue at the [questionnaire repository](https://github.com/{{ secrets.data.covariates_repo | default('<gh_user>/<name>') }}):
-        - [ ] Under the section `Issues`, click on <span class="consolebutton green">New issue</span>
-        - [ ] Select the `Mood questionnaire after scan` template by clicking on <span class="consolebutton green">Get started</span>
-    - [ ] Fill in the session id (accessible in the [schedule](participant-prep.md/#session-schedule-reliability))
-    - [ ] Ask the participant to fill the rest of the form
+- [ ] Collect post-scan information (e.g., whether the participant fell asleep) as follows:
+    - [ ] Click [this link](https://github.com/{{ secrets.data.covariates_repo | default('<gh_user>/<name>') }}/issues/new?assignees=celprov&labels=mood%2Cafter&projects=&template=mood-questionnaire-after.yml&title=%5BMOOD%5D%5BAFTER%5D+sub-001_ses-yyy), or alternatively
+    - [ ] Open a *GitHub Issue* in the [covariate collection repository](https://github.com/{{ secrets.data.covariates_repo | default('<gh_user>/<name>') }}):
+        - [ ] Click on the *Issues* tab.
+        - [ ] Click on <span class="consolebutton green">New issue</span>.
+        - [ ] Select the corresponding template for the *Mood questionnaire after scan* (either reliability or standard protocol) by clicking on its <span class="consolebutton green">Get started</span> button.
+    - [ ] Fill in the session identifier (prescribed in the [schedule](participant-prep.md/#session-schedule-reliability))
+    - [ ] Ask the participant to fill out the rest of the form
 - [ ] Solicit tickets and receipts for transportation.
 - [ ] Give the participant the corresponding compensation for the participation and transportation.
 - [ ] Ask the participant to sign the receipt of the amount of the financial compensation.

--- a/docs/data-collection/tear-up.md
+++ b/docs/data-collection/tear-up.md
@@ -296,8 +296,9 @@ A laptop should be available to fill the issue.
 - [ ] [Click this link](https://github.com/{{ secrets.data.covariates_repo | default('<gh_user>/<name>') }}/issues/new?assignees=acionca&labels=mood%2Cbefore&projects=&template=mood-questionnaire-before.yml&title=%5BMOOD%5D%5BBEFORE%5D+sub-001_ses-yyy), or alternatively
 - [ ] manually open a GitHub Issue at the [questionnaire repository](https://github.com/{{ secrets.data.covariates_repo | default('<gh_user>/<name>') }}):
     - [ ] Under the section `Issues`, click on <span class="consolebutton green">New issue</span>
+    - [ ] Select the template `Mood questionnaire before scan` by clicking on <span class="consolebutton green">Get started</span>
 
-- [ ] Fill the date of the scan as well as the PE for this session (accessible in the [schedule](scanning.md/#before-initiating-the-session))
+- [ ] Fill the date of the scan as well as the PE for this session (accessible in the [schedule](participant-prep.md/#session-schedule-reliability))
 - [ ] Fill in weather details of the scanning day based [MeteoSwiss](https://www.meteoswiss.admin.ch/local-forecasts/lausanne/1003.html#forecast-tab=detail-view) in 1003 Lausanne.
     - [ ] Report the maximum and minimum temperature in degrees celsius.
     - [ ] Report the wind speed at the time of scanning in km/h.

--- a/docs/data-collection/tear-up.md
+++ b/docs/data-collection/tear-up.md
@@ -296,9 +296,9 @@ A laptop should be available to fill the issue.
 - [ ] [Click this link](https://github.com/{{ secrets.data.covariates_repo | default('<gh_user>/<name>') }}/issues/new?assignees=acionca&labels=mood%2Cbefore&projects=&template=mood-questionnaire-before.yml&title=%5BMOOD%5D%5BBEFORE%5D+sub-001_ses-yyy), or alternatively
 - [ ] manually open a GitHub Issue at the [questionnaire repository](https://github.com/{{ secrets.data.covariates_repo | default('<gh_user>/<name>') }}):
     - [ ] Under the section `Issues`, click on <span class="consolebutton green">New issue</span>
-    - [ ] Select the template `Mood questionnaire before scan` by clicking on <span class="consolebutton green">Get started</span>
+    - [ ] Select the corresponding template for the *Mood questionnaire before scan* (either reliability or standard protocol)  by clicking on its <span class="consolebutton green">Get started</span> button.
 
-- [ ] Fill the date of the scan as well as the PE for this session (accessible in the [schedule](participant-prep.md/#session-schedule-reliability))
+- [ ] Fill out the date of the scan as well as the PE for this session (prescribed in the corresponding [schedule table](participant-prep.md/#session-schedule-reliability))
 - [ ] Fill in weather details of the scanning day based [MeteoSwiss](https://www.meteoswiss.admin.ch/local-forecasts/lausanne/1003.html#forecast-tab=detail-view) in 1003 Lausanne.
     - [ ] Report the maximum and minimum temperature in degrees celsius.
     - [ ] Report the wind speed at the time of scanning in km/h.


### PR DESCRIPTION
fix: fix the link to check which PE direction and which day is the session acquired
fix: add link to the after-scan mood questionnaire
fix: precise which issue template to use