### PR TITLE
MAINT: fix incompatibilities in FC computation

### DIFF
--- a/code/fmri/funconn.py
+++ b/code/fmri/funconn.py
@@ -48,7 +48,7 @@ from nilearn._utils import stringify_path
 from nilearn.connectome import ConnectivityMeasure, vec_to_sym_matrix
 from nilearn.interfaces.fmriprep import load_confounds
 from nilearn.maskers import MultiNiftiMapsMasker
-from nilearn.signal import _handle_scrubbed_volumes, _sanitize_confounds, clean
+from nilearn.signal import _handle_scrubbed_volumes, _sanitize_confound_dtype, clean
 
 from reports import plot_interpolation, visual_report_timeserie, visual_report_fc
 from load_save import (
@@ -317,7 +317,7 @@ def interpolate_and_denoise_timeseries(
         )
 
         # This is required as we are manually doing some internal Nilearn machinery
-        conf = _sanitize_confounds(ts.shape[0], n_runs=1, confounds=conf)
+        conf = _sanitize_confound_dtype(ts.shape[0], confound=conf)
         conf = stringify_path(conf)
 
         ts_to_interpolate = ts.copy()

--- a/code/fmri/launch_funconn.sh
+++ b/code/fmri/launch_funconn.sh
@@ -1,1 +1,1 @@
-python funconn.py /home/cprovins/data/hcph-derivatives/fmriprep-23.1.4-wp/ --task qct --ses 001 003 004 005 006 008 009
+python funconn.py /data/derivatives/hcph-derivatives-rsmovie/hcph-fmriprep/ --task rsmovie --atlas-dimension 128 --fc-estimator correlation

--- a/code/fmri/nilearn_patcher.py
+++ b/code/fmri/nilearn_patcher.py
@@ -62,7 +62,7 @@ import itertools
 
 from joblib import Memory, Parallel, delayed
 
-from nilearn._utils.niimg_conversions import _iter_check_niimg
+from nilearn._utils.niimg_conversions import iter_check_niimg
 from nilearn.maskers.nifti_maps_masker import NiftiMapsMasker
 
 

--- a/code/fmri/reports.py
+++ b/code/fmri/reports.py
@@ -34,7 +34,6 @@ import pandas as pd
 import plotly.offline as pyo
 import seaborn as sns
 from matplotlib.axes import Axes
-from matplotlib.cm import get_cmap
 from matplotlib.lines import Line2D
 from nireports.assembler.report import Report
 from nilearn.plotting import plot_design_matrix, plot_matrix
@@ -109,7 +108,7 @@ def plot_timeseries_carpet(
         net_dict = {net: i + 1 for i, net in enumerate(networks_sorted.unique())}
         net_plot = np.array([[net_dict[net] for net in networks_sorted]])
 
-        net_cmap = get_cmap(NETWORK_CMAP, len(net_dict))
+        net_cmap = plt.get_cmap(NETWORK_CMAP, len(net_dict))
         ax_net.imshow(net_plot.T, cmap=NETWORK_CMAP, aspect="auto")
 
         legend_elements = [
@@ -207,7 +206,7 @@ def plot_timeseries_signal(
         net_dict = {net: i + 1 for i, net in enumerate(networks_sorted.unique())}
         net_plot = np.array([[net_dict[net] for net in networks_sorted]])
 
-        net_cmap = get_cmap(NETWORK_CMAP, len(net_dict))
+        net_cmap = plt.get_cmap(NETWORK_CMAP, len(net_dict))
 
         colors = [net_cmap(i - 1) for i in net_plot][0]
 


### PR DESCRIPTION
fix to be compatible with nilearn version 0.10.4
@oesteban should I change the required version of nilearn in requirements.txt ?

fix: deprecation warning of matplotlib because it moved the location of the get_cmap function