### PR TITLE
FIX: add scale and fdthresh as entities for FC filenames

### DIFF
--- a/code/fmri/funconn.py
+++ b/code/fmri/funconn.py
@@ -626,7 +626,7 @@ def main():
         logging.info(
             f"{len(all_missing_ts + missing_only_fc)} files are missing FC matrices."
         )
-        existing_timeseries = load_timeseries(missing_only_fc, output)
+        existing_timeseries = load_timeseries(missing_only_fc, output, fdthresh=fd_threshold_str)
     else:
         missing_only_fc = []
         existing_timeseries = []
@@ -717,7 +717,7 @@ def main():
             patterns=FC_PATTERN,
             meas=fc_label,
             scale=atlas_dimension,
-            fdthresh=fd_threshold_str
+            fdthresh=fd_threshold_str,
             **FC_FILLS,
         )
 

--- a/code/fmri/funconn.py
+++ b/code/fmri/funconn.py
@@ -555,6 +555,7 @@ def main():
     denoising_strategy = args.denoising_strategy
     motion = args.motion
     fd_threshold = args.FD_thresh
+    fd_threshold_str = str(fd_threshold).replace(".", "")
     std_dvars_threshold = args.SDVARS_thresh
     scrub = args.n_scrub_frames
     fc_estimator = args.fc_estimator
@@ -613,13 +614,14 @@ def main():
             all_filenames,
             return_existing=True,
             patterns=TIMESERIES_PATTERN,
+            fdthresh=fd_threshold_str,
             **TIMESERIES_FILLS,
         )
 
         logging.info(f"{len(all_missing_ts)} files are missing timeseries.")
         logging.debug("Looking for existing fc matrices ...")
         missing_only_fc = check_existing_output(
-            output, all_existing_ts, patterns=FC_PATTERN, meas=fc_label, scale=atlas_dimension, **FC_FILLS
+            output, all_existing_ts, patterns=FC_PATTERN, meas=fc_label, scale=atlas_dimension, fdthresh=fd_threshold_str, **FC_FILLS
         )
         logging.info(
             f"{len(all_missing_ts + missing_only_fc)} files are missing FC matrices."
@@ -668,6 +670,7 @@ def main():
             sorted_missing_ts,
             output,
             patterns=TIMESERIES_PATTERN,
+            fdthresh=fd_threshold_str,
             **TIMESERIES_FILLS,
         )
 
@@ -681,6 +684,7 @@ def main():
                 confounds=confounds,
                 labels=atlas_labels,
                 networks=atlas_network,
+                fdthresh=fd_threshold_str,
             )
 
     fc_matrices = compute_connectivity(
@@ -712,6 +716,8 @@ def main():
             output,
             patterns=FC_PATTERN,
             meas=fc_label,
+            scale=atlas_dimension,
+            fdthresh=fd_threshold_str
             **FC_FILLS,
         )
 
@@ -723,6 +729,8 @@ def main():
                 output=output,
                 labels=atlas_labels,
                 meas=fc_label,
+                scale=atlas_dimension,
+                fdthresh=fd_threshold_str
             )
 
     logging.info(

--- a/code/fmri/funconn.py
+++ b/code/fmri/funconn.py
@@ -598,9 +598,7 @@ def main():
     atlas_network = getattr(atlas_data, "labels").loc[:, NETWORK_MAPPING]
 
     if output is None:
-        output = op.join(
-            find_derivative(input_path), "functional_connectivity"
-        )
+        output = op.join(find_derivative(input_path), "functional_connectivity")
     logging.info(f"Output will be save as derivatives in:\n\t{output}")
 
     covar_estimator, fc_kind, fc_label = get_fc_strategy(fc_estimator)
@@ -621,12 +619,20 @@ def main():
         logging.info(f"{len(all_missing_ts)} files are missing timeseries.")
         logging.debug("Looking for existing fc matrices ...")
         missing_only_fc = check_existing_output(
-            output, all_existing_ts, patterns=FC_PATTERN, meas=fc_label, scale=atlas_dimension, fdthresh=fd_threshold_str, **FC_FILLS
+            output,
+            all_existing_ts,
+            patterns=FC_PATTERN,
+            meas=fc_label,
+            scale=atlas_dimension,
+            fdthresh=fd_threshold_str,
+            **FC_FILLS,
         )
         logging.info(
             f"{len(all_missing_ts + missing_only_fc)} files are missing FC matrices."
         )
-        existing_timeseries = load_timeseries(missing_only_fc, output, fdthresh=fd_threshold_str)
+        existing_timeseries = load_timeseries(
+            missing_only_fc, output, fdthresh=fd_threshold_str
+        )
     else:
         missing_only_fc = []
         existing_timeseries = []
@@ -730,7 +736,7 @@ def main():
                 labels=atlas_labels,
                 meas=fc_label,
                 scale=atlas_dimension,
-                fdthresh=fd_threshold_str
+                fdthresh=fd_threshold_str,
             )
 
     logging.info(

--- a/code/fmri/funconn.py
+++ b/code/fmri/funconn.py
@@ -597,15 +597,8 @@ def main():
     atlas_network = getattr(atlas_data, "labels").loc[:, NETWORK_MAPPING]
 
     if output is None:
-        run_name = f"DiFuMo{atlas_dimension:d}"
-        if study_name:
-            run_name = "-".join([study_name, run_name])
-
-        run_name += (low_pass is not None) * "-LP"
-        run_name += (interpolate) * "-noCensoring"
-
         output = op.join(
-            find_derivative(input_path), "functional_connectivity", run_name
+            find_derivative(input_path), "functional_connectivity"
         )
     logging.info(f"Output will be save as derivatives in:\n\t{output}")
 
@@ -626,7 +619,7 @@ def main():
         logging.info(f"{len(all_missing_ts)} files are missing timeseries.")
         logging.debug("Looking for existing fc matrices ...")
         missing_only_fc = check_existing_output(
-            output, all_existing_ts, patterns=FC_PATTERN, meas=fc_label, **FC_FILLS
+            output, all_existing_ts, patterns=FC_PATTERN, meas=fc_label, scale=atlas_dimension, **FC_FILLS
         )
         logging.info(
             f"{len(all_missing_ts + missing_only_fc)} files are missing FC matrices."

--- a/code/fmri/load_save.py
+++ b/code/fmri/load_save.py
@@ -332,7 +332,7 @@ def reorder_iqms(iqms_df: pd.DataFrame, fc_paths: list[str]):
     iqms_df = iqms_df.assign(
         subject=iqms_df["bids_name"].str.extract(r"sub-(\d+)_"),
         session=iqms_df["bids_name"].str.extract(r"ses-(\w+)_"),
-        task=iqms_df["bids_name"].str.extract(r"task-(\w+)_")
+        task=iqms_df["bids_name"].str.extract(r"task-(\w+)_"),
     )
     entities_list = [parse_file_entities(filepath) for filepath in fc_paths]
     entities_df = pd.DataFrame(entities_list)
@@ -451,7 +451,9 @@ def check_existing_output(
     return missing_data.tolist()
 
 
-def load_timeseries(func_filename: list[str], output: str, **kwargs) -> list[np.ndarray]:
+def load_timeseries(
+    func_filename: list[str], output: str, **kwargs
+) -> list[np.ndarray]:
     """Load existing timeseries from .csv files.
 
     Parameters

--- a/code/fmri/load_save.py
+++ b/code/fmri/load_save.py
@@ -42,14 +42,14 @@ from nilearn.interfaces.fmriprep.load_confounds import _load_single_confounds_fi
 
 FC_PATTERN: list = [
     "sub-{subject}[/ses-{session}]/func/sub-{subject}"
-    "[_ses-{session}][_task-{task}][_meas-{meas}][_scale-{atlas_dimension}]"
+    "[_ses-{session}][_task-{task}][_meas-{meas}][_scale-{scale}][_fdthresh-{fdthresh}]"
     "_{suffix}{extension}"
 ]
 FC_FILLS: dict = {"suffix": "connectivity", "extension": ".tsv"}
 
 TIMESERIES_PATTERN: list = [
     "sub-{subject}[/ses-{session}]/func/sub-{subject}"
-    "[_ses-{session}][_task-{task}][_desc-{desc}]"
+    "[_ses-{session}][_task-{task}][_fdthresh-{fdthresh}][_desc-{desc}]"
     "_{suffix}{extension}"
 ]
 TIMESERIES_FILLS: dict = {"desc": "denoised", "extension": ".tsv"}

--- a/code/fmri/load_save.py
+++ b/code/fmri/load_save.py
@@ -42,7 +42,7 @@ from nilearn.interfaces.fmriprep.load_confounds import _load_single_confounds_fi
 
 FC_PATTERN: list = [
     "sub-{subject}[/ses-{session}]/func/sub-{subject}"
-    "[_ses-{session}][_task-{task}][_meas-{meas}]"
+    "[_ses-{session}][_task-{task}][_meas-{meas}][_scale-{atlas_dimension}]"
     "_{suffix}{extension}"
 ]
 FC_FILLS: dict = {"suffix": "connectivity", "extension": ".tsv"}

--- a/code/fmri/load_save.py
+++ b/code/fmri/load_save.py
@@ -42,7 +42,7 @@ from nilearn.interfaces.fmriprep.load_confounds import _load_single_confounds_fi
 
 FC_PATTERN: list = [
     "sub-{subject}[/ses-{session}]/func/sub-{subject}"
-    "[_ses-{session}][_task-{task}][_meas-{meas}][_scale-{scale}][_fdthresh-{fdthresh}]"
+    "[_ses-{session}][_task-{task}][_scale-{scale}][_fdthresh-{fdthresh}][_meas-{meas}]"
     "_{suffix}{extension}"
 ]
 FC_FILLS: dict = {"suffix": "connectivity", "extension": ".tsv"}

--- a/code/fmri/load_save.py
+++ b/code/fmri/load_save.py
@@ -451,7 +451,7 @@ def check_existing_output(
     return missing_data.tolist()
 
 
-def load_timeseries(func_filename: list[str], output: str) -> list[np.ndarray]:
+def load_timeseries(func_filename: list[str], output: str, **kwargs) -> list[np.ndarray]:
     """Load existing timeseries from .csv files.
 
     Parameters
@@ -472,7 +472,7 @@ def load_timeseries(func_filename: list[str], output: str) -> list[np.ndarray]:
     loaded_ts = []
     for filename in func_filename:
         path_to_ts = get_bids_savename(
-            filename, patterns=TIMESERIES_PATTERN, **TIMESERIES_FILLS
+            filename, patterns=TIMESERIES_PATTERN, **TIMESERIES_FILLS, **kwargs
         )
         logging.debug(f"\t{op.join(output, path_to_ts)}")
         loaded_ts.append(

--- a/code/fmri/reports.py
+++ b/code/fmri/reports.py
@@ -297,6 +297,7 @@ def visual_report_timeserie(
     filename: str,
     output: str,
     confounds: Optional[np.ndarray] = None,
+    fdthresh: Optional[float] = None,
     **kwargs,
 ) -> None:
     """Plot and save the timeseries visual reports.
@@ -311,13 +312,15 @@ def visual_report_timeserie(
         Path to the output directory
     confounds : Optional[np.ndarray], optional
         Confounds to plot, by default None
+    fdthresh : Optional[float], optional
+        value of the FD threshold to inform filename, by default None
     """
     # Plotting denoised and aggregated timeseries
     for plot_func, plot_desc in zip(
         [plot_timeseries_carpet, plot_timeseries_signal], ["carpetplot", "timeseries"]
     ):
         ts_saveloc = get_bids_savename(
-            filename, patterns=FIGURE_PATTERN, desc=plot_desc, **FIGURE_FILLS, **kwargs
+            filename, patterns=FIGURE_PATTERN, desc=plot_desc, fdthresh=fdthresh, **FIGURE_FILLS
         )
         plot_func(timeseries, **kwargs)
 
@@ -330,7 +333,7 @@ def visual_report_timeserie(
     # Plotting confounds as a design matrix
     if confounds is not None:
         conf_saveloc = get_bids_savename(
-            filename, patterns=FIGURE_PATTERN, desc="designmatrix", **FIGURE_FILLS
+            filename, patterns=FIGURE_PATTERN, desc="designmatrix", fdthresh=fdthresh, **FIGURE_FILLS
         )
 
         _, ax = plt.subplots(figsize=TS_FIGURE_SIZE)

--- a/code/fmri/reports.py
+++ b/code/fmri/reports.py
@@ -320,7 +320,11 @@ def visual_report_timeserie(
         [plot_timeseries_carpet, plot_timeseries_signal], ["carpetplot", "timeseries"]
     ):
         ts_saveloc = get_bids_savename(
-            filename, patterns=FIGURE_PATTERN, desc=plot_desc, fdthresh=fdthresh, **FIGURE_FILLS
+            filename,
+            patterns=FIGURE_PATTERN,
+            desc=plot_desc,
+            fdthresh=fdthresh,
+            **FIGURE_FILLS,
         )
         plot_func(timeseries, **kwargs)
 
@@ -333,7 +337,11 @@ def visual_report_timeserie(
     # Plotting confounds as a design matrix
     if confounds is not None:
         conf_saveloc = get_bids_savename(
-            filename, patterns=FIGURE_PATTERN, desc="designmatrix", fdthresh=fdthresh, **FIGURE_FILLS
+            filename,
+            patterns=FIGURE_PATTERN,
+            desc="designmatrix",
+            fdthresh=fdthresh,
+            **FIGURE_FILLS,
         )
 
         _, ax = plt.subplots(figsize=TS_FIGURE_SIZE)

--- a/code/fmri/reports.py
+++ b/code/fmri/reports.py
@@ -46,7 +46,7 @@ from load_save import get_bids_savename
 
 FIGURE_PATTERN: list = [
     "sub-{subject}/figures/sub-{subject}[_ses-{session}]"
-    "[_task-{task}][_meas-{meas}][_desc-{desc}]"
+    "[_task-{task}][_meas-{meas}][_scale-{scale}][_fdthresh-{fdthresh}][_desc-{desc}]"
     "_{suffix}{extension}",
     "sub-{subject}/figures/sub-{subject}[_ses-{session}]"
     "[_task-{task}][_desc-{desc}]_{suffix}{extension}",
@@ -317,7 +317,7 @@ def visual_report_timeserie(
         [plot_timeseries_carpet, plot_timeseries_signal], ["carpetplot", "timeseries"]
     ):
         ts_saveloc = get_bids_savename(
-            filename, patterns=FIGURE_PATTERN, desc=plot_desc, **FIGURE_FILLS
+            filename, patterns=FIGURE_PATTERN, desc=plot_desc, **FIGURE_FILLS, **kwargs
         )
         plot_func(timeseries, **kwargs)
 

--- a/code/fmri/reports.py
+++ b/code/fmri/reports.py
@@ -46,7 +46,7 @@ from load_save import get_bids_savename
 
 FIGURE_PATTERN: list = [
     "sub-{subject}/figures/sub-{subject}[_ses-{session}]"
-    "[_task-{task}][_meas-{meas}][_scale-{scale}][_fdthresh-{fdthresh}][_desc-{desc}]"
+    "[_task-{task}][_scale-{scale}][_fdthresh-{fdthresh}][_meas-{meas}][_desc-{desc}]"
     "_{suffix}{extension}",
     "sub-{subject}/figures/sub-{subject}[_ses-{session}]"
     "[_task-{task}][_desc-{desc}]_{suffix}{extension}",


### PR DESCRIPTION
fix: because we promised to perform the analyses with different atlas scale, indicate the scale of the atlas in the name of the FC files rather than in the directory name.
fix: because we promised to perform the analyses with different FD threshold, add the FD threshold as an entity to save in the filenames for both timeseries and FC matrices.
fix: do not modify the directory name depending on whether lowpass filtering and censoring were performed or not.

This is what the output running funconn on two sessions looks like:

> functional_connectivity
> ├── fMRI_duration_after_censoring.csv
> └── sub-001
>     ├── figures
>     │   ├── sub-001_ses-001_task-rsmovie_fdthresh-04_desc-carpetplot_bold.png
>     │   ├── sub-001_ses-001_task-rsmovie_fdthresh-04_desc-designmatrix_bold.png
>     │   ├── sub-001_ses-001_task-rsmovie_fdthresh-04_desc-timeseries_bold.png
>     │   ├── sub-001_ses-001_task-rsmovie_meas-correlation_scale-64_fdthresh-04_desc-heatmap_bold.png
>     │   ├── sub-001_ses-003_task-rsmovie_fdthresh-04_desc-carpetplot_bold.png
>     │   ├── sub-001_ses-003_task-rsmovie_fdthresh-04_desc-designmatrix_bold.png
>     │   ├── sub-001_ses-003_task-rsmovie_fdthresh-04_desc-timeseries_bold.png
>     │   └── sub-001_ses-003_task-rsmovie_meas-correlation_scale-64_fdthresh-04_desc-heatmap_bold.png
>     ├── ses-001
>     │   └── func
>     │       ├── sub-001_ses-001_task-rsmovie_fdthresh-04_desc-denoised_bold.tsv
>     │       └── sub-001_ses-001_task-rsmovie_meas-correlation_scale-64_fdthresh-04_connectivity.tsv
>     └── ses-003
>         └── func
>             ├── sub-001_ses-003_task-rsmovie_fdthresh-04_desc-denoised_bold.tsv
>             └── sub-001_ses-003_task-rsmovie_meas-correlation_scale-64_fdthresh-04_connectivity.tsv
> 
> 6 directories, 13 files