### PR TITLE
FIX: explanation on how to run fMRIPrep

### DIFF
--- a/code/fmriprep/fmriprep.sbatch
+++ b/code/fmriprep/fmriprep.sbatch
@@ -25,7 +25,7 @@
 #SBATCH --mem=128G 
 #SBATCH --time=24:00:00 
 #SBATCH --export=NONE
-#SBATCH --chdir=/scratch/cprovins
+#SBATCH --chdir=/scratch/%u
 #
 # Logging
 #SBATCH --output=/users/%u/logs/%x-%A-%a.out
@@ -34,7 +34,7 @@
 ml singularityce gcc
 
 WORKDIR={{ secrets.data.curnagl_workdir | default('<workdir>')}}
-SCRATCH=/scratch/cprovins/fmriprep/
+SCRATCH={{ secrets.data.curnagl_scratchdir | default('<scratchdir>')}}/fmriprep/
 OUTDIR=$WORKDIR/data/derivatives/fmriprep-generalization/
 
 mkdir -p $OUTDIR

--- a/code/fmriprep/fmriprep.sbatch
+++ b/code/fmriprep/fmriprep.sbatch
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Copyright 2024 The Axon Lab <theaxonlab@gmail.com> 
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0 
+# 
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+###########################################################################
+#
+# General SLURM settings
+#SBATCH --mail-type=ALL 
+#SBATCH --mail-user=<email>@unil.ch
+#
+# Job settings
+#SBATCH --job-name=fmriprep
+#SBATCH --partition=cpu
+#SBATCH --cpus-per-task=10
+#SBATCH --mem=128G 
+#SBATCH --time=24:00:00 
+#SBATCH --export=NONE
+#SBATCH --chdir=/scratch/cprovins
+#
+# Logging
+#SBATCH --output=/users/%u/logs/%x-%A-%a.out
+#SBATCH --error=/users/%u/logs/%x-%A-%a.err
+
+ml singularityce gcc
+
+WORKDIR={{ secrets.data.curnagl_workdir | default('<workdir>')}}
+SCRATCH=/scratch/cprovins/fmriprep/
+OUTDIR=$WORKDIR/data/derivatives/fmriprep-generalization/
+
+mkdir -p $OUTDIR
+mkdir -p $SCRATCH
+
+export SINGULARITYENV_FS_LICENSE=$HOME/freesurfer.txt
+
+singularity exec --cleanenv \
+        -B $WORKDIR/workspace/fmriprep/fmriprep:/opt/conda/envs/fmriprep/lib/python3.11/site-packages/fmriprep \
+	    -B $WORKDIR/data/hcph-dataset:/data/datasets/hcph/ \
+        -B $OUTDIR:/out \
+        -B $SCRATCH:/tmp \
+        -B ${HOME}/.cache/templateflow/tpl-MNI152NLin6Asym/:${HOME}/.cache/templateflow/tpl-MNI152NLin6Asym/ \
+        docker://nipreps/fmriprep:24.1.1 \
+        fmriprep /data/datasets/hcph/ /out participant \
+        --participant-label 001 \
+        --fs-subjects-dir /out/sourcedata/freesurfer \
+        --nprocs 4 --omp-nthreads ${SLURM_CPUS_PER_TASK} \
+        -w /tmp/ -vv --skip-bids-validation
+
+echo "Completed with return code: $?"

--- a/code/fmriprep/fmriprep.sbatch
+++ b/code/fmriprep/fmriprep.sbatch
@@ -16,7 +16,7 @@
 #
 # General SLURM settings
 #SBATCH --mail-type=ALL 
-#SBATCH --mail-user=<email>@unil.ch
+#SBATCH --mail-user={{ secrets.data.curnagl_email | default('<email>@unil.ch') }}
 #
 # Job settings
 #SBATCH --job-name=fmriprep

--- a/code/fmriprep/submit-fmriprep.sh
+++ b/code/fmriprep/submit-fmriprep.sh
@@ -38,7 +38,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-DATADIR="/oak/stanford/groups/russpold/inprocess/cprovins/hcph-pilot/"
+DATADIR=<workdir>/data/hcph-dataset
 SUB="sub-001"
 pushd $DATADIR/inputs/$SUB > /dev/null
 ALL_SES=(`ls -d ses-*`)

--- a/code/fmriprep/submit-fmriprep.sh
+++ b/code/fmriprep/submit-fmriprep.sh
@@ -38,7 +38,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-DATADIR=<workdir>/data/hcph-dataset
+DATADIR={{ secrets.data.curnagl_workdir | default('<workdir>') }}/data/hcph-dataset
 SUB="sub-001"
 pushd $DATADIR/inputs/$SUB > /dev/null
 ALL_SES=(`ls -d ses-*`)

--- a/code/fmriprep/submit-fmriprep.sh
+++ b/code/fmriprep/submit-fmriprep.sh
@@ -54,8 +54,6 @@ for S in "${ALL_SES[@]}"; do
         fi
 done
 
-echo "Submitting `basename $DATADIR` with ${#SES[@]} sessions"
-# remove one since we are starting at 0
-JOBS=`expr ${#SES[@]} - 1`
+#remove one since we are starting at 0
+JOBS=`expr ${\#SES[@]} - 1`
 sbatch --array=0-$JOBS ss-fmriprep.sh $DATADIR ${SES[@]}
-

--- a/docs/processing/preprocessing.md
+++ b/docs/processing/preprocessing.md
@@ -69,11 +69,18 @@
             ```
 
     - [ ] Once the anatomical workflow ran successfully, submit a *job array* with one scanning session each with the `--bids-filter-file` argument selecting the corresponding session, and point the `--fs-subjects-dir` argument to the folder where *FreeSurfer* results were stored.
-        ``` bash
-        cd code/fmriprep
-        bash submit-fmriprep.sh
-        ```
-        
+   
+    ``` bash title="Bash script to submit a job array with one scanning session each"
+    {% filter indent(width=4) %}
+    {% include 'code/fmriprep/submit-fmriprep.sh' %}
+    {% endfilter %}
+    ```
+
+    ``` bash title="Sbatch to submit a single session (corresponding to ss-fmriprep.sh in the script above)"
+    {% filter indent(width=4) %}
+    {% include 'code/fmriprep/ss-fmriprep.sh' %}
+    {% endfilter %}
+    ```
 
 
 ### How to proceed if some *fMRIPrep* derivatives are missing

--- a/docs/processing/preprocessing.md
+++ b/docs/processing/preprocessing.md
@@ -39,27 +39,36 @@
     sbatch fmriprep-anatonly.sbatch
     ```
 
-    ??? abstract "The sbatch file to run *fMRIPrep* with `--anat-only`"
-
-        ``` bash
-{% filter indent(width=8) %}
-{% include 'code/fmriprep/ss-fmriprep-anatonly.sh' %}
-{% endfilter %}
-        ```
-
 - [ ] Once the anatomical workflow ran successfully, submit a *job array* with one scanning session each with the `--bids-filter-file` argument selecting the corresponding session, and point the `--fs-subjects-dir` argument to the folder where *FreeSurfer* results were stored.
-    ``` bash title="Launch each session through fMRIPrep in parallel"
-    cd code/fmriprep
-    bash ss-fmriprep.sh
-    ```
-
-    ??? abstract "The sbatch file to run *fMRIPrep* session-wise"
-
+    -  [ ] To avoid conflicts when multiple fMRIPrep instances write to the same file simultaneously, we recommend pre-downloading the template with TemplateFlow.
+        - [ ] If not yet installed, install *TemplateFlow* using Pypi
         ``` bash
-{% filter indent(width=8) %}
-{% include 'code/fmriprep/ss-fmriprep.sh' %}
-{% endfilter %}
+        pip install templateflow
         ```
+        - [ ] Download the template using the Python client. By default, the template will be saved under `$HOME/.cache/templateflow`.
+        We will then mount that path into the container running *fMRIPrep*.
+        ``` bash
+        python
+        from templateflow import api as tflow
+        tflow.get('MNI152NLin6Asym', desc=None, resolution=1, suffix='T1w', extension='nii.gz')
+        ```
+
+    - [ ] 
+        ``` bash title="Launch each session through fMRIPrep in parallel"
+        cd code/fmriprep
+        bash submit-fmriprep.sh
+        ```
+
+        ??? abstract "The sbatch file to run *fMRIPrep* session-wise"
+
+            ``` bash
+    {% filter indent(width=8) %}
+    {% include 'code/fmriprep/ss-fmriprep.sh' %}
+    {% endfilter %}
+            ```
+    
+
+
 
 ### How to proceed if some *fMRIPrep* derivatives are missing
 

--- a/docs/processing/preprocessing.md
+++ b/docs/processing/preprocessing.md
@@ -39,35 +39,41 @@
     sbatch fmriprep-anatonly.sbatch
     ```
 
-- [ ] Once the anatomical workflow ran successfully, submit a *job array* with one scanning session each with the `--bids-filter-file` argument selecting the corresponding session, and point the `--fs-subjects-dir` argument to the folder where *FreeSurfer* results were stored.
-    -  [ ] To avoid conflicts when multiple fMRIPrep instances write to the same file simultaneously, we recommend pre-downloading the template with TemplateFlow.
-        - [ ] If not yet installed, install *TemplateFlow* using Pypi
-        ``` bash
-        pip install templateflow
-        ```
-        - [ ] Download the template using the Python client. By default, the template will be saved under `$HOME/.cache/templateflow`.
-        We will then mount that path into the container running *fMRIPrep*.
-        ``` bash
-        python
-        from templateflow import api as tflow
-        tflow.get('MNI152NLin6Asym', desc=None, resolution=1, suffix='T1w', extension='nii.gz')
-        ```
+### Executing functional workflow
 
-    - [ ] 
-        ``` bash title="Launch each session through fMRIPrep in parallel"
+- [ ] Create a SLURM *sbatch* file, for example at `$HOME/fmriprep.sbatch`:
+
+    ``` bash
+{% filter indent(width=4) %}
+{% include 'code/fmriprep/fmriprep.sbatch' %}
+{% endfilter %}
+    ```
+
+- [ ] Submit the functional workflow:
+    ``` bash
+    sbatch fmriprep.sbatch
+    ```
+
+??? abstract "If running all sessions in a single job is too heavy, you can follow the following steps to run *fMRIPrep* on each session in parallel"
+
+    - [ ] To avoid conflicts when multiple *fMRIPrep* instances write to the same file simultaneously, we recommend pre-downloading the template with TemplateFlow.
+
+        - [ ] If not yet installed, install *TemplateFlow* using *PyPi*
+            ``` bash
+            pip install templateflow
+            ```
+        - [ ] Use the *TemplateFlow* Python client to download the template, which is saved by default to `$HOME/.cache/templateflow`. In the SLURM *sbatch* file, we will mount that path into the container. To download the template, open a Python session by typing `python` and then run the following commands:
+            ``` python
+            from templateflow import api as tflow
+            tflow.get('MNI152NLin6Asym', desc=None, resolution=1, suffix='T1w', extension='nii.gz')
+            ```
+
+    - [ ] Once the anatomical workflow ran successfully, submit a *job array* with one scanning session each with the `--bids-filter-file` argument selecting the corresponding session, and point the `--fs-subjects-dir` argument to the folder where *FreeSurfer* results were stored.
+        ``` bash
         cd code/fmriprep
         bash submit-fmriprep.sh
         ```
-
-        ??? abstract "The sbatch file to run *fMRIPrep* session-wise"
-
-            ``` bash
-    {% filter indent(width=8) %}
-    {% include 'code/fmriprep/ss-fmriprep.sh' %}
-    {% endfilter %}
-            ```
-    
-
+        
 
 
 ### How to proceed if some *fMRIPrep* derivatives are missing


### PR DESCRIPTION
fix: add sbatch to run functional workflow of fMRIPrep
fix: indicate the option fMRIPrep in parallel for each session as an alternative if running all sessions in one job is too heavy
enh: precise how to pre-download the template
fix: delete the outdated mention of my fMRIPrep anat-only sbatch