### PR TITLE
FIX: adapt `funconn_group.py` to the new nomenclature of FC matrices

### DIFF
--- a/code/fmri/funconn_group.py
+++ b/code/fmri/funconn_group.py
@@ -34,6 +34,8 @@ from load_save import (
     get_atlas_data,
     find_atlas_dimension,
     load_iqms,
+    FC_FILLS,
+    FC_PATTERN
 )
 from reports import (
     group_report,

--- a/code/fmri/funconn_group.py
+++ b/code/fmri/funconn_group.py
@@ -34,8 +34,6 @@ from load_save import (
     get_atlas_data,
     find_atlas_dimension,
     load_iqms,
-    FC_FILLS,
-    FC_PATTERN
 )
 from reports import (
     group_report,

--- a/code/fmri/funconn_group.py
+++ b/code/fmri/funconn_group.py
@@ -110,7 +110,7 @@ def main():
     mriqc_path = args.mriqc_path
     fc_label = args.fc_estimator.replace(" ", "")
     scale = args.atlas_dimension
-    fdthresh = args.FD_thresh
+    fdthresh = str(args.FD_thresh).replace(".", "")
 
     verbosity_level = args.verbosity
 

--- a/code/fmri/funconn_group.py
+++ b/code/fmri/funconn_group.py
@@ -28,9 +28,7 @@ import numpy as np
 import os.path as op
 import pandas as pd
 
-
 from itertools import chain
-
 from load_save import (
     get_atlas_data,
     find_atlas_dimension,
@@ -42,7 +40,6 @@ from load_save import (
     FC_FILLS,
     FC_PATTERN
 )
-
 from reports import (
     group_report,
 )
@@ -80,6 +77,19 @@ def get_arguments() -> argparse.Namespace:
         'sparse')""",
     )
     parser.add_argument(
+        "--atlas-dimension",
+        default=64,
+        type=int,
+        help="dimension of the atlas (usually 64, 128 or 512)",
+    )
+    parser.add_argument(
+        "--FD-thresh",
+        default=0.5,
+        action="store",
+        type=float,
+        help="framewise displacement threshold (in mm)",
+    )
+    parser.add_argument(
         "-v",
         "--verbosity",
         action="count",
@@ -99,6 +109,8 @@ def main():
     task_filter = args.task
     mriqc_path = args.mriqc_path
     fc_label = args.fc_estimator.replace(" ", "")
+    scale = args.atlas_dimension
+    fdthresh = args.FD_thresh
 
     verbosity_level = args.verbosity
 
@@ -134,6 +146,8 @@ def main():
         return_existing=True,
         return_output=True,
         patterns=FC_PATTERN,
+        scale=scale,
+        fdthresh=fdthresh,
         meas=fc_label,
         **FC_FILLS,
     )
@@ -141,7 +155,7 @@ def main():
         filename = op.join(
             output,
             get_bids_savename(
-                all_filenames[0], patterns=FC_PATTERN, meas=fc_label, **FC_FILLS
+                all_filenames[0], patterns=FC_PATTERN, scale=scale, fdthresh= fdthresh, meas=fc_label, **FC_FILLS
             ),
         )
         raise ValueError(

--- a/code/fmri/funconn_group.py
+++ b/code/fmri/funconn_group.py
@@ -132,7 +132,7 @@ def main():
 
     # Find all existing functional connectivity
     # Initialize the BIDS layout, we use a custom indexer because we are using entities that are not yet officially recognized by BIDS 
-    config_path = "../bids/indexer.json"
+    config_path = op.abspath(op.join(op.dirname(__file__), "../bids/indexer.json"))
     try:
         add_config_paths(hcph=config_path)
     except ValueError as e:

--- a/code/fmri/funconn_group.py
+++ b/code/fmri/funconn_group.py
@@ -150,8 +150,8 @@ def main():
         extension=".tsv",
         suffix="connectivity",
         task=task_filter,
-        meas=fc_label,
-        fdthresh=fdthresh,
+        measure=fc_label,
+        fd_threshold=fdthresh,
         scale=scale,
     )
     if not existing_fc:

--- a/code/fmri/funconn_group.py
+++ b/code/fmri/funconn_group.py
@@ -28,17 +28,12 @@ import numpy as np
 import os.path as op
 import pandas as pd
 
-from itertools import chain
+from bids.layout import BIDSLayout, BIDSLayoutIndexer, add_config_paths
+
 from load_save import (
     get_atlas_data,
     find_atlas_dimension,
-    find_derivative,
-    check_existing_output,
-    get_bids_savename,
-    get_func_filenames_bids,
     load_iqms,
-    FC_FILLS,
-    FC_PATTERN
 )
 from reports import (
     group_report,
@@ -136,30 +131,33 @@ def main():
     atlas_filename = getattr(atlas_data, "maps")
 
     # Find all existing functional connectivity
-    input_path = find_derivative(output)
-    func_filenames, _ = get_func_filenames_bids(input_path, task_filter=task_filter)
-    all_filenames = list(chain.from_iterable(func_filenames))
-
-    existing_fc = check_existing_output(
-        output,
-        all_filenames,
-        return_existing=True,
-        return_output=True,
-        patterns=FC_PATTERN,
-        scale=scale,
-        fdthresh=fdthresh,
+    # Initialize the BIDS layout, we use a custom indexer because we are using entities that are not yet officially recognized by BIDS 
+    config_path = "../bids/indexer.json"
+    try:
+        add_config_paths(hcph=config_path)
+    except ValueError as e:
+        if "Configuration 'hcph' already exists" in str(e):
+            print("Configuration 'hcph' already exists, skipping add_config_paths.")
+        else:
+            raise e
+    _indexer = BIDSLayoutIndexer(
+        config_filename=config_path,
+        index_metadata=False,
+        validate=False,
+    )       
+    layout = BIDSLayout(output, config="hcph", indexer=_indexer, validate=False)
+    existing_fc = layout.get(
+        extension=".tsv",
+        suffix="connectivity",
+        task=task_filter,
         meas=fc_label,
-        **FC_FILLS,
+        fdthresh=fdthresh,
+        scale=scale,
     )
     if not existing_fc:
-        filename = op.join(
-            output,
-            get_bids_savename(
-                all_filenames[0], patterns=FC_PATTERN, scale=scale, fdthresh= fdthresh, meas=fc_label, **FC_FILLS
-            ),
-        )
         raise ValueError(
-            f"No functional connectivity of type {filename} were found. Please revise the arguments."
+            f"No functional connectivity matrices found in {output} with task {task_filter}, meas {fc_label},"
+            f"fdthresh {fdthresh}, and scale {scale}."
         )
 
     # Load functional connectivity matrices

--- a/code/fmri/funconn_group.py
+++ b/code/fmri/funconn_group.py
@@ -30,7 +30,6 @@ import pandas as pd
 
 
 from itertools import chain
-from funconn import FC_FILLS, FC_PATTERN
 
 from load_save import (
     get_atlas_data,
@@ -40,6 +39,8 @@ from load_save import (
     get_bids_savename,
     get_func_filenames_bids,
     load_iqms,
+    FC_FILLS,
+    FC_PATTERN
 )
 
 from reports import (

--- a/code/fmri/load_save.py
+++ b/code/fmri/load_save.py
@@ -248,8 +248,16 @@ def find_atlas_dimension(path: str, atlas_name: str = "DiFuMo") -> int:
     if dimension_match:
         return int(dimension_match.group(1))
     else:
+        # We now store the value of the atlas dimension in a BIDS entity
+        # Traverse the directory to find files matching the pattern
+        for root, _, files in os.walk(path):
+            for file in files:
+                if re.match(rf".*_scale-(\d+).*_connectivity\.tsv", file):
+                    dimension_match = re.search(r"_scale-(\d+)", file)
+                    if dimension_match:
+                        return int(dimension_match.group(1))
         raise ValueError(
-            f"The output path {path} does not contain the expected pattern: {atlas_name} followed by digits."
+            f"The output path {path} does not contain any of the expected patterns: {atlas_name} followed by digits or the scale BIDS entity."
         )
 
 


### PR DESCRIPTION
In PR #517, I modified the way the output of `funconn.py` are written. 
I added fdthresh, scale and meas as BIDS entities and instead of indicating the atlas dimension in the folder name (e.g DiFuMo64), I indicated it with the scale BIDS entity.

These changes required to adapt the implementation of `funconn_group.py`.
Instead of relying on the in-house code implemented in `load_save.py` to get a list of all FC matrices filenames, which works only with a specific folder organization, I use our customized BIDS indexer (see #522). This change was moreover needed so that the group report generation consider only the FC matrices that correspond to a specific FD threshold, atlas-dimension and measure, instead of considering all FC matrices available in the folder.