### PR TITLE
FIX: remove spaces in sparse inverse covariance argument

### DIFF
--- a/code/fmri/funconn.py
+++ b/code/fmri/funconn.py
@@ -182,12 +182,12 @@ def get_arguments() -> argparse.Namespace:
     )
     parser.add_argument(
         "--fc-estimator",
-        default="sparse inverse covariance",
+        default="sparseinversecovariance",
         action="store",
-        choices=["correlation", "covariance", "sparse", "sparse inverse covariance"],
+        choices=["correlation", "covariance", "sparse", "sparseinversecovariance"],
         type=str,
-        help="""type of connectivity to compute (can be 'correlation', 'covariance' or
-        'sparse')""",
+        help="""type of connectivity to compute (can be 'correlation', 'covariance',
+        'sparse' or 'sparseinversecovariance')""",
     )
     parser.add_argument(
         "--no-censor",
@@ -465,7 +465,7 @@ def extract_and_denoise_timeseries(
 
 
 def get_fc_strategy(
-    strategy: str = "sparse inverse covariance",
+    strategy: str = "sparseinversecovariance",
 ) -> tuple[Union[GraphicalLassoCV, LedoitWolf], str, str]:
     """Get the strategy to compute functional connectivity.
 
@@ -473,7 +473,7 @@ def get_fc_strategy(
     ----------
     strategy : str, optional
         Name of the strategy, could be "correlation", "covariance" or "sparse",
-        by default "sparse inverse covariance"
+        by default "sparseinversecovariance"
 
     Returns
     -------
@@ -489,7 +489,7 @@ def get_fc_strategy(
         connectivity_kind = "correlation"
         connectivity_label = "correlation"
         estimator = LedoitWolf(store_precision=False)
-    elif strategy not in ["sparse", "sparse inverse covariance"]:
+    elif strategy not in ["sparse", "sparseinversecovariance"]:
         connectivity_kind = "covariance"
         connectivity_label = "covariance"
 

--- a/code/fmri/funconn_group.py
+++ b/code/fmri/funconn_group.py
@@ -71,9 +71,9 @@ def get_arguments() -> argparse.Namespace:
     )
     parser.add_argument(
         "--fc-estimator",
-        default="sparse inverse covariance",
+        default="sparseinversecovariance",
         action="store",
-        choices=["correlation", "covariance", "sparse", "sparse inverse covariance"],
+        choices=["correlation", "covariance", "sparse", "sparseinversecovariance"],
         type=str,
         help="""type of connectivity to compute (can be 'correlation', 'covariance' or
         'sparse')""",

--- a/code/fmri/tests/test_load_save.py
+++ b/code/fmri/tests/test_load_save.py
@@ -110,7 +110,7 @@ def test_find_atlas_dimension(path, expected_dim):
 
 @pytest.mark.parametrize("return_existing", [False, True])
 @pytest.mark.parametrize("return_output", [False, True])
-@pytest.mark.parametrize("fc_label", ["sparse inverse covariance", "correlation"])
+@pytest.mark.parametrize("fc_label", ["sparseinversecovariance", "correlation"])
 def test_check_existing_output(return_existing, return_output, fc_label, tmp_path):
     func_filename = ["sub-1/func/sub-1_bold.nii", "sub-2/func/sub-2_bold.nii"]
     existing_filenames = [


### PR DESCRIPTION
because command line cannot parse words with spaces