### PR TITLE
Correct details in the funconn documentation

### DIFF
--- a/docs/processing/functional-connectivity.md
+++ b/docs/processing/functional-connectivity.md
@@ -24,7 +24,7 @@ python funconn.py path_to_dataset/derivatives/fmriprep-23.1.4
     
     - [ ] Fetch the [DiFuMo](https://doi.org/10.1016/j.neuroimage.2020.117126) atlas (64 dimensions)
     - [ ] Extract the region-wise averaged timeseries
-    - [ ] Find high motion volumes that have framewise displacement higher than 0.4 mm or higher than 5 standardized DVAR.
+    - [ ] Find high motion volumes that have framewise displacement higher than 0.5 mm or higher than 5 standardized DVAR.
     Then also flag as outlier the segments that are shorter than 5 timepoints.
     - [ ] Interpolate high motion volumes with cubic spline interpolation
     - [ ] Apply a low-pass butterworth filter (cutoff frequency of 0.15 Hz)
@@ -66,6 +66,7 @@ In the end, the data structure will look like this:
 │               └── ses-15
 │                   └── func
 ```
+Note that an alternative output directory can be specified using the `--output` flag.
 
 ## QA/QC of functional connectivity
 


### PR DESCRIPTION
fix: fix the default FD threshold in the documentation as it was not matching the implementation
doc: add a note that you can use --output to change output directory of funconn since in the end I always specified an alternative directory when computing FC matrices