### PR TITLE
DOC: modify the description of FC connectivity computation...

### DIFF
--- a/docs/analysis/fmri-variability.ipynb
+++ b/docs/analysis/fmri-variability.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +35,7 @@
     "\n",
     "#Define filtering parameters\n",
     "metric = \"correlation\"\n",
-    "atlas_dimension = \"128\"\n",
+    "atlas_dimension = 128\n",
     "fd_threshold = 0.5\n",
     "fdthresh_str = str(fd_threshold).replace(\".\", \"\")\n",
     "\n",
@@ -57,17 +57,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Configuration 'hcph' already exists, skipping add_config_paths.\n",
       "[get_dataset_dir] Dataset found in /home/cprovins/nilearn_data/difumo_atlases\n",
       "Configuration 'hcph' already exists, skipping add_config_paths.\n",
       "Number of brain regions (matrix size): 119\n",
-      "Shape of concatenated upper triangle FC matrices (number of region pairs, number of sessions): (36, 7140)\n"
+      "Shape of concatenated upper triangle FC matrices (number of sessions, number of region pairs): (36, 7140)\n"
      ]
     },
     {
@@ -87,7 +88,7 @@
     "    'subject': '001',\n",
     "    'task': 'rsmovie',\n",
     "    'measure': metric,\n",
-    "    'scale': atlas_dimension,\n",
+    "    'scale': str(atlas_dimension),\n",
     "    'fd_threshold': fdthresh_str,\n",
     "}\n",
     "\n",
@@ -113,7 +114,17 @@
     "plt.ylabel('Brain Regions')\n",
     "\n",
     "print(f\"Number of brain regions (matrix size): {fc_size}\")\n",
-    "print(f\"Shape of concatenated upper triangle FC matrices (number of region pairs, number of sessions): {fc_concat.shape}\")"
+    "print(f\"Shape of concatenated upper triangle FC matrices (number of sessions, number of region pairs): {fc_concat.shape}\")\n",
+    "\n",
+    "# Test whether the shape is as expected\n",
+    "assert fc_concat.shape == (36, fc_size * (fc_size + 1) // 2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One remark to note is the number of brain regions does not correspond to the atlas_dimension, because we removed from the DiFuMo atlas the components that are specific to the CSF, ventricles and sinuses."
    ]
   },
   {

--- a/docs/processing/functional-connectivity.md
+++ b/docs/processing/functional-connectivity.md
@@ -23,6 +23,7 @@ python funconn.py path_to_dataset/derivatives/fmriprep-23.1.4
     When using the default options, the pipeline will (in this order and for all functional tasks):
     
     - [ ] Fetch the [DiFuMo](https://doi.org/10.1016/j.neuroimage.2020.117126) atlas (64 dimensions)
+    - [ ] Removes from the atlas the components that are specific to CSF, ventricles, and sinuses, as those regions are not of interest for connectivity estimation (2 regions removed at scale 64, 9 at scale 128, and 30 at scale 512).
     - [ ] Extract the region-wise averaged timeseries
     - [ ] Find high motion volumes that have framewise displacement higher than 0.5 mm or higher than 5 standardized DVAR.
     Then also flag as outlier the segments that are shorter than 5 timepoints.


### PR DESCRIPTION
...to explain that we removed the atlas components specific to CSF, in turn explaining the mismatch between atlas dimension and number of brain regions.