### PR TITLE
HOTFIX: Pin & upgrade MkDocs stack, drop unused mkpdfs, add MathJax SRI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         git config --global user.email "nipreps@gmail.com"
         git config --global user.name "nipreps-bot"
         python -m pip install --upgrade pip
-        pip install -r src/requirements.txt
+        pip install -r src/requirements-docs.txt
     - uses: actions/checkout@v4
       with:
         ref: gh-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
         git config --global user.email "nipreps@gmail.com"
         git config --global user.name "nipreps-bot"
         python -m pip install --upgrade pip
+        pip install -r src/requirements.txt
         pip install -r src/requirements-docs.txt
     - uses: actions/checkout@v4
       with:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
 
 theme:
   name: material
+  custom_dir: overrides
   font:
     text: Urbanist
   palette:
@@ -139,5 +140,7 @@ extra_css:
   - stylesheets/extra.css
 
 extra_javascript:
+  # Local MathJax 3 configuration; loads before the MathJax library.
+  # The library itself is injected with a pinned version + SRI hash in
+  # overrides/main.html (MkDocs cannot set an `integrity` attribute here).
   - js/mathjax.js
-  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{#
+  Load the MathJax 3 library from a pinned jsDelivr URL with Subresource
+  Integrity (SRI). MkDocs' `extra_javascript` cannot express an `integrity`
+  attribute, so the library is injected here instead. The local MathJax
+  configuration (`js/mathjax.js`) is still loaded via `extra_javascript`
+  and runs first, before this library script (appended after `super()`).
+
+  Do NOT reintroduce polyfill.io here: that domain was sold in 2024 and
+  began serving malware. MathJax 3 needs no polyfill on supported browsers.
+#}
+{% block scripts %}
+  {{ super() }}
+  <script
+    src="https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-mml-chtml.js"
+    integrity="sha512-tiaNmAzpy3KcgtuiLwT9WSlSsqGqtDB5ylMwxoqG5ysNIyzkBw24k6UFTuXGgyXJLJ8aM/ho1h67NRKedPx++Q=="
+    crossorigin="anonymous"></script>
+{% endblock %}

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,15 @@
+# Pinned dependency set used to BUILD the documentation site (CI: deploy.yml).
+# Keep this reproducible: exact pins only. Notebooks are rendered from stored
+# outputs (mkdocs-jupyter execute=False), so the scientific/analysis stack is
+# NOT needed here -- it lives in requirements.txt.
+#
+# NOTE: the old mkpdfs-mkdocs-plugin (unpinned @master git fork) and its
+# WeasyPrint<53 dependency were removed: the `mkpdfs` plugin is disabled in
+# mkdocs.yml and the fork is an unmaintained supply-chain liability.
+markdown-include==0.8.1
+mkdocs==1.6.1
+mkdocs-jupyter==0.26.3
+mkdocs-macros-plugin==1.5.0
+mkdocs-material==9.7.6
+pymdown-extensions==10.16.1
+Pygments==2.19.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
+# Full authoring environment: the pinned docs-build stack plus the
+# scientific/analysis dependencies used to (re)generate the notebooks under
+# docs/. CI only needs requirements-docs.txt to build the site.
+-r requirements-docs.txt
+
+# Authoring/QA tooling
 codespell
-markdown-include
-mkdocs
-mkdocs-jupyter
-mkdocs-macros-plugin
-mkdocs-material>=9.4
 git-changelog
-git+https://github.com/dimrozakis/mkpdfs-mkdocs-plugin.git@master
-pygments
-weasyprint<53
+
+# Scientific/analysis stack for the notebooks (rendered from stored outputs)
 matplotlib
 pybids
 nilearn>=0.10.1


### PR DESCRIPTION
This PR removes the pollyfill.io import that was used to serve malware.

Make the documentation build reproducible and harden its supply chain:

- Split deps: new pinned requirements-docs.txt is all CI needs to build the site; requirements.txt now pulls it in via -r and keeps the scientific stack used to regenerate the notebooks. deploy.yml installs the docs file.
- Pin the docs stack to exact versions (verified building on Python 3.12): mkdocs==1.6.1, mkdocs-material==9.7.6, mkdocs-jupyter==0.26.3, mkdocs-macros-plugin==1.5.0, pymdown-extensions==10.16.1, Pygments==2.19.2, markdown-include==0.8.1.
- Drop the mkpdfs-mkdocs-plugin (unpinned @master git fork) and its WeasyPrint<53 dependency: the mkpdfs plugin is disabled in mkdocs.yml and the fork is an unmaintained supply-chain liability.
- Pin the MathJax 3 CDN asset (mathjax@3.2.2) and add Subresource Integrity. MkDocs cannot set an integrity attribute via extra_javascript, so the library is injected through a Material theme override (overrides/main.html); the local js/mathjax.js config still loads first.