### PR TITLE
FIX: Repair post-session.md includes after ``bids`` -> ``data_loader`` rename

### DIFF
--- a/docs/data-management/post-session.md
+++ b/docs/data-management/post-session.md
@@ -96,7 +96,7 @@ To support backward compatibility (and some extra, currently unsupported feature
 
         ``` text
 {% filter indent(width=8) %}
-{% include 'code/bids/example01.txt' %}
+{% include 'code/data_loader/example01.txt' %}
 {% endfilter %}
         ```
 
@@ -106,7 +106,7 @@ To support backward compatibility (and some extra, currently unsupported feature
 
         ``` text
 {% filter indent(width=8) %}
-{% include 'code/bids/example02.txt' %}
+{% include 'code/data_loader/example02.txt' %}
 {% endfilter %}
         ```
 


### PR DESCRIPTION
The recent rename of the `bids` code folder to `data_loader` (to avoid the clash with the pybids package) left two macros includes in post-session.md pointing at the old `code/bids/` path, producing a macro rendering error on every build. Point them at `code/data_loader/example0{1,2}.txt`.