### PR TITLE
MAINT: Repository hygiene cleanup (broken links, CI, deps, stale paths)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,9 @@
 [codespell]
-skip = *.pdf,./site/*,./design/*,./docs/stylesheets/*,*-fr.md,./code/heudiconv/*.py,./include/abbreviations.md,*.ipynb
+# Skip generated/asset files that are not prose: SVG figures and the bundled
+# third-party MRIQC sample report produce ~1200 false positives.
+skip = *.pdf,*.svg,./site/*,./design/*,./docs/stylesheets/*,./docs/assets/files/*,*-fr.md,./code/heudiconv/*.py,./include/abbreviations.md,*.ipynb
+# 'mot' is a task-condition label used as a code token, not a typo of 'not'.
+ignore-words-list = mot
 builtin = clear,rare,en-GB_to_en-US
 count =
 quiet-level = 3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Run tests
 
-on: [push, pull-request]
+on: [push, pull_request]
 
 jobs:  
   codespell:
@@ -9,6 +9,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Codespell
-        uses: codespell-project/actions-codespell@v1
+        uses: codespell-project/actions-codespell@v2

--- a/code/confounds/parse_mood_quest.py
+++ b/code/confounds/parse_mood_quest.py
@@ -569,7 +569,7 @@ df.loc[df["session_number"] == "014", slept_columns] = "n/a"
 # Complete that the scanner used for the reliability sessions was the Prisma
 df.loc[df["session_number"].str.startswith("0"), "scanner"] = "Prisma"
 
-# put colunm name in small caps
+# put column name in small caps
 df.columns = df.columns.str.lower()
 
 # Save to CSV

--- a/code/fmri/reports.py
+++ b/code/fmri/reports.py
@@ -620,7 +620,7 @@ def group_reportlet_qc_fc(
         percent_match_ks = (1 - ks_statistic) * 100
 
         # Plot the box in red if the correlation is significant
-        facecolor = "red" if percent_match_ks < PERCENT_MATCH_CUT_OFF else "grey"
+        facecolor = "red" if percent_match_ks < PERCENT_MATCH_CUT_OFF else "gray"
         axs[i].text(
             0.08,
             0.9,
@@ -709,7 +709,7 @@ def group_reportlet_qc_fc_euclidean(
         correlation, p_value = pearsonr(qc_fc, d)
 
         # Plot the box in red if the correlation is significant
-        facecolor = "red" if p_value < ALPHA else "grey"
+        facecolor = "red" if p_value < ALPHA else "gray"
         axs[i].text(
             0.15,
             0.97,

--- a/docs/analysis/icc.ipynb
+++ b/docs/analysis/icc.ipynb
@@ -110,7 +110,7 @@
     "confounds_path = dataset_path / \"phenotype\" / \"mood_env_quest.tsv\"\n",
     "\n",
     "# Initialize the BIDS layout\n",
-    "config_path = code_path / \"code/bids/indexer.json\"\n",
+    "config_path = code_path / \"code/data_loader/indexer.json\"\n",
     "try:\n",
     "    add_config_paths(hcph=config_path)\n",
     "except ValueError as e:\n",

--- a/docs/data-collection/emergency-procedures.md
+++ b/docs/data-collection/emergency-procedures.md
@@ -28,7 +28,7 @@
 !!! danger "**If at any point the participant rings the alarm**, you MUST check on the participant IMMEDIATELY with the scanner's speaker system."
 
     - [ ] Press the speaker button (1 in the picture below) and ask if everything is alright. It is possible that the participant triggered the alarm by mistake.
-        ![speaker](../assets/images/speaker.jpg)
+        ![speaker](../assets/images/speakers.png)
 
         !!! warning "Pressing the speaker button (1) or the crossed-bell button (4) will turn the alarm off and open the speaker line to talk to the participant."
 

--- a/docs/data-collection/tear-up.md
+++ b/docs/data-collection/tear-up.md
@@ -42,7 +42,7 @@ The following section describes how to prepare the session on the day of scan, B
 - [ ] Turn BIOPAC's {{ settings.biopac.model }} on with the switch on its back panel.
 - [ ] Open the *AcqKnowledge* software
 - [ ] Select *Create new graph from recently used file* ⤷ select `EXP_BASE.gtl` and click *Open*.
-- [ ] Initiate an *Amphetamin* session to prevent the computer from going to sleep or locking the screen:
+- [ ] Initiate an *Amphetamine* session to prevent the computer from going to sleep or locking the screen:
     - [ ] Click on the pill icon on the Mac's status bar
     - [ ] Select *New session* ⤷ *While is running* ⤷ *Acqknowledge*.
 

--- a/docs/data-management/edf-to-bids.md
+++ b/docs/data-management/edf-to-bids.md
@@ -27,7 +27,7 @@ Our ET device produces EyeLink's EDF recording files, which will be accessed wit
 
 The code snippets are extracted from the [`EyeTrackingRun` object](../assets/code/eyetracking/eyetrackingrun.py), an object we implemented for converting EDF data to BIDS.
 
-!!! warning "Disclamer: despite this code attempting to be general, some parts focus on single-eye recordings"
+!!! warning "Disclaimer: despite this code attempting to be general, some parts focus on single-eye recordings"
 
 ### Parsing the `messages` dataframe
 

--- a/docs/data-management/preliminary.md
+++ b/docs/data-management/preliminary.md
@@ -2,7 +2,7 @@
 
 This project maintains data under version control thanks to *DataLad*<sup>[1]</sup>.
 For instructions on how to setup *DataLad* on your PC, please refer to the [official documentation](https://handbook.datalad.org/en/latest/intro/installation.html).
-When employing high-performance computing (HPC), we provide [some specific guidelines](../processing/our-cluster.md).
+When employing high-performance computing (HPC), we provide [some specific guidelines](../processing/environment.md).
 
 !!! important "Please read the [*DataLad Handbook*](https://handbook.datalad.org/en/latest/index.html), especially if you are new to this tool"
 

--- a/docs/data-management/preliminary.md
+++ b/docs/data-management/preliminary.md
@@ -165,7 +165,7 @@ In this case, the steps are demonstrated for the outputs of *sMRIPrep*.
                 {{ secrets.data.gh_derivs_repo | default('<organization>/<repo_name>') }}
         ```
 
-        If successfull, the output in this case should be something like:
+        If successful, the output in this case should be something like:
 
         ``` Text
         create_sibling_github(ok): [sibling repository 'github' created at https://github.com/<organization>/<repo_name>]

--- a/docs/data-management/qaqc-general.md
+++ b/docs/data-management/qaqc-general.md
@@ -35,7 +35,7 @@ The following admonition will be present to remind this strategy when it applies
 Consistently with this approach, the exclusion criteria for the QCT and the BHT at the different QC checkpoints are very permissive.
 The following admonition will remind this aspect when it applies:
 
-???+ important "IMPORTANT — QCT and BHT runs with low quality MUST be flagged, but they SHOULT NOT be excluded."
+???+ important "IMPORTANT — QCT and BHT runs with low quality MUST be flagged, but they SHOULD NOT be excluded."
 
     The BHT and QCT were primarily acquired for QA/QC purposes and to aid in methodological development (e.g., denoising of the RSfMRI).
     This QA/QC protocol should be revised if the task fMRI data are employed for different purposes.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,17 +4,18 @@
 -r requirements-docs.txt
 
 # Authoring/QA tooling
-codespell
-git-changelog
+codespell==2.4.1
+git-changelog==2.6.3
 
-# Scientific/analysis stack for the notebooks (rendered from stored outputs)
-matplotlib
-pybids
-nilearn>=0.10.1
-git+https://github.com/celprov/mriqc-learn.git@enh/xgboost_model
-arviz
-h5py
-pymc
-seaborn
-plotly
-nireports
+# Scientific/analysis stack for the notebooks (rendered from stored outputs).
+# Pinned for reproducibility; the git fork is pinned to a commit (not a branch).
+matplotlib==3.10.6
+pybids==0.20.0
+nilearn==0.12.1
+git+https://github.com/celprov/mriqc-learn.git@c612f902ea44cda94fecd4df382c9af5d3b38c09
+arviz==0.22.0
+h5py==3.14.0
+pymc==5.25.1
+seaborn==0.13.2
+plotly==6.3.1
+nireports==25.3.0


### PR DESCRIPTION
## Why

Follow-up to the MkDocs upgrade: a full-repo audit surfaced several low-risk defects that
hurt build reliability and reproducibility. This applies the safe, mechanical fixes.
`mkdocs build` is **now warning-free** (was 2 warnings).

## Fixes

- **docs — broken image link.** `data-collection/emergency-procedures.md` referenced
  `assets/images/speaker.jpg`, which doesn't exist → `speakers.png` (the real file).
- **docs — broken HPC link.** `data-management/preliminary.md` linked to a non-existent
  `processing/our-cluster.md` → repointed to `processing/environment.md` (the actual
  cluster/DataLad setup page).
- **ci — `tests.yml` never ran on PRs.** Trigger was `pull-request` (invalid event name) →
  `pull_request`. Also bumped `actions/checkout@v3→v4` and `…/actions-codespell@v1→v2`.
- **fix — stale path after `bids`→`data_loader` rename.** `analysis/icc.ipynb` →
  `code/data_loader/indexer.json` (last remaining `code/bids/` reference).
- **build — pin the scientific stack.** `requirements.txt` now pins matplotlib, pybids,
  nilearn, arviz, h5py, pymc, seaborn, plotly, nireports, codespell, git-changelog to exact
  versions, and pins the `mriqc-learn` fork to a commit SHA instead of a moving branch.

## Flagged separately (NOT changed here — need a human decision)

- **`deploy.yml` redundant double install** — `pip install -r requirements.txt` already pulls
  `-r requirements-docs.txt`, so the second `pip install -r requirements-docs.txt` is redundant.
  Left as-is since it was added deliberately.
- **Secrets submodule** — `secrets/` is the private `*****` submodule; no secret reaches
  the public build (CI can't init the SSH submodule; macros `on_undefined: lax`). Worth confirming
  `hcph-secrets` is private.
- **Orphan pages** — `analysis/bayesian_modeling_synth_example.ipynb` and `analysis/README.md`
  are not in `nav`; decide whether the synth-example notebook should be published.

## Verification

- `mkdocs build` → exit 0, **0 warnings**.
- `git grep "code/bids/"` → empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)