### PR TITLE
fix: remove invalid '\\<' escape in a macro default (jinja DeprecationWarning)

### DIFF
--- a/docs/data-collection/setup.md
+++ b/docs/data-collection/setup.md
@@ -291,7 +291,7 @@ To install it as a service, please follow [the documentation in the appendix](no
 
 ### Prepare data management (intake and backup) with {{ secrets.hosts.oesteban | default("███") }}
 
-We employ *{{ secrets.hosts.oesteban | default("███") }}* as the server to automatically upload data to the backup repository (*{{ secrets.data.curnagl_backup | default("\<user>@\<host>:\<path>") }}*).
+We employ *{{ secrets.hosts.oesteban | default("███") }}* as the server to automatically upload data to the backup repository (*{{ secrets.data.curnagl_backup | default("&lt;user&gt;@&lt;host&gt;:&lt;path&gt;") }}*).
 For the physiological recordings (acquired on *{{ secrets.hosts.acqknowledge | default("███") }}* for BIOPAC-registered signals, and on *{{ secrets.hosts.psychopy | default("███") }}* for the eye-tracking), data is synchronized into *{{ secrets.hosts.oesteban | default("███") }}* via *Dropbox*.
 
 - [ ] Create a softlink pointing to the BIOPAC data:


### PR DESCRIPTION
## Why

Closes #545. The build emitted a `DeprecationWarning: invalid escape sequence '\<'` from
`docs/data-collection/setup.md`, which used `default("\<user>@\<host>:\<path>")` inside a *macros*
(jinja) expression — `\<` is not a valid escape. (The broken-link warnings #545 also listed were
already fixed in #564/#566; the build is otherwise warning-free.)

## Fix

Use the repository's HTML-entity convention for angle-bracket placeholders —
`&lt;user&gt;@&lt;host&gt;:&lt;path&gt;` — matching the other `default(...)` placeholders in the
docs (e.g. `&lt;hostname&gt;`, `&lt;organization&gt;/&lt;repo_name&gt;`).

## Verification

- `mkdocs build` → exit 0, **0 warnings**, and the `invalid escape` DeprecationWarning is gone.
- codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)